### PR TITLE
WEB-2573 - 20869 - Local de entrega para emissão de NF-e.

### DIFF
--- a/src/NFe/DanfeEtiqueta.php
+++ b/src/NFe/DanfeEtiqueta.php
@@ -17,8 +17,8 @@ class DanfeEtiqueta extends DaCommon
     protected $email = null;
     protected $xml; // string XML NFe
     protected $dom;
-    protected $logomarca=''; // path para logomarca em jpg
-    protected $formatoChave="#### #### #### #### #### #### #### #### #### #### ####";
+    protected $logomarca = ''; // path para logomarca em jpg
+    protected $formatoChave = "#### #### #### #### #### #### #### #### #### #### ####";
     protected $nfeProc;
     protected $nfe;
     protected $infNFe;
@@ -52,6 +52,8 @@ class DanfeEtiqueta extends DaCommon
     protected $aFont = [];
     protected $canceled = false;
     protected $submessage = null;
+    protected $entrega;
+    protected $retirada;
 
     /**
      * Construtor
@@ -159,10 +161,10 @@ class DanfeEtiqueta extends DaCommon
         //total inicial de paginas
         $totPag = 1;
         //largura imprimivel em mm: largura da folha menos as margens esq/direita
-        $this->wPrint = $maxW-($margEsq * 2);
+        $this->wPrint = $maxW - ($margEsq * 2);
         //comprimento (altura) imprimivel em mm: altura da folha menos as margens
         //superior e inferior
-        $this->hPrint = $maxH-$margSup-$margInf;
+        $this->hPrint = $maxH - $margSup - $margInf;
         $this->orientacao = 'P';
         $this->papel = [$this->paperwidth, $this->paperlength];
         $this->logoAlign = 'L';
@@ -231,9 +233,9 @@ class DanfeEtiqueta extends DaCommon
         }
         $aFont = ['font' => $this->fontePadrao, 'size' => 10, 'style' => ''];
         $texto = "NFe n. " . $numNF . '   Série: ' . $serie . '  ' . $tipo;
-        $y += $this->pdf->textBox($this->margem, $y+2, $this->wPrint, 7, $texto, $aFont, 'T', 'C', 0, '');
-        $this->pdf->line($this->margem, $y+4, $this->wPrint+$this->margem, $y+4);
-        return $y+4;
+        $y += $this->pdf->textBox($this->margem, $y + 2, $this->wPrint, 7, $texto, $aFont, 'T', 'C', 0, '');
+        $this->pdf->line($this->margem, $y + 4, $this->wPrint + $this->margem, $y + 4);
+        return $y + 4;
     }
 
     protected function bloco2($y)
@@ -258,22 +260,22 @@ class DanfeEtiqueta extends DaCommon
             }
         }
         $h = 20;
-        $maxHimg = $h-2;
+        $maxHimg = $h - 2;
         if (!empty($this->logomarca)) {
             $xImg = $this->margem + 2;
             $logoInfo = getimagesize($this->logomarca);
-            $logoWmm = ($logoInfo[0]/72)*25.4;
-            $logoHmm = ($logoInfo[1]/72)*25.4;
-            $nImgW = $this->wPrint/4;
-            $nImgH = round($logoHmm * ($nImgW/$logoWmm), 0);
+            $logoWmm = ($logoInfo[0] / 72) * 25.4;
+            $logoHmm = ($logoInfo[1] / 72) * 25.4;
+            $nImgW = $this->wPrint / 4;
+            $nImgH = round($logoHmm * ($nImgW / $logoWmm), 0);
             if ($nImgH > $maxHimg) {
                 $nImgH = $maxHimg;
-                $nImgW = round($logoWmm * ($nImgH/$logoHmm), 0);
+                $nImgW = round($logoWmm * ($nImgH / $logoHmm), 0);
             }
             $xRs = ($nImgW) + $this->margem;
             $wRs = ($this->wPrint - $nImgW);
             $alignH = 'L';
-            $yImg = ($h - $nImgH)/2 + $y;
+            $yImg = ($h - $nImgH) / 2 + $y;
             $this->pdf->image($this->logomarca, $xImg, $yImg, $nImgW, $nImgH, 'jpeg');
         } else {
             $xRs = $this->margem;
@@ -281,13 +283,13 @@ class DanfeEtiqueta extends DaCommon
             $alignH = 'C';
         }
         //COLOCA RAZÃO SOCIAL
-        $aFont = ['font'=>$this->fontePadrao, 'size' => 9, 'style' => 'B'];
+        $aFont = ['font' => $this->fontePadrao, 'size' => 9, 'style' => 'B'];
         $texto = "{$emitRazao}";
         $y += $this->pdf->textBox(
-            $xRs+2,
+            $xRs + 2,
             $y,
-            $wRs-2,
-            $this->margem-1,
+            $wRs - 2,
+            $this->margem - 1,
             $texto,
             $aFont,
             'T',
@@ -296,19 +298,129 @@ class DanfeEtiqueta extends DaCommon
             '',
             true
         );
-        $aFont = ['font'=>$this->fontePadrao, 'size' => 8, 'style' => ''];
+        $aFont = ['font' => $this->fontePadrao, 'size' => 8, 'style' => ''];
         $texto = "CNPJ: {$emitCnpj} IE: {$emitIE}";
-        $y += $this->pdf->textBox($xRs+2, $y, $wRs-2, 3, $texto, $aFont, 'T', $alignH, false, '', true);
+        $y += $this->pdf->textBox($xRs + 2, $y, $wRs - 2, 3, $texto, $aFont, 'T', $alignH, false, '', true);
         $texto = $emitLgr . ", " . $emitNro;
-        $y += $this->pdf->textBox($xRs+2, $y, $wRs-2, 3, $texto, $aFont, 'T', $alignH, false, '', true);
+        $y += $this->pdf->textBox($xRs + 2, $y, $wRs - 2, 3, $texto, $aFont, 'T', $alignH, false, '', true);
         $texto = $emitBairro;
-        $y += $this->pdf->textBox($xRs+2, $y, $wRs-2, 3, $texto, $aFont, 'T', $alignH, false, '', true);
-        $texto = $emitMun . "-" . $emitUF . ($emitFone ? "  Fone: ".$emitFone : "");
-        $y += $this->pdf->textBox($xRs+2, $y, $wRs-2, 3, $texto, $aFont, 'T', $alignH, false, '', true);
+        $y += $this->pdf->textBox($xRs + 2, $y, $wRs - 2, 3, $texto, $aFont, 'T', $alignH, false, '', true);
+        $texto = $emitMun . "-" . $emitUF . ($emitFone ? "  Fone: " . $emitFone : "");
+        $y += $this->pdf->textBox($xRs + 2, $y, $wRs - 2, 3, $texto, $aFont, 'T', $alignH, false, '', true);
         $texto = "E-mail: {$this->email}";
-        $y += $this->pdf->textBox($xRs+2, $y, $wRs-2, 3, $texto, $aFont, 'T', $alignH, false, '', true);
-        $this->pdf->line($this->margem, $y+2, $this->wPrint+$this->margem, $y+2);
-        return $y+2;
+        $y += $this->pdf->textBox($xRs + 2, $y, $wRs - 2, 3, $texto, $aFont, 'T', $alignH, false, '', true);
+
+        $isDelivery = !empty($this->getTagValue($this->entrega, 'CNPJ'))
+            ||  !empty($this->getTagValue($this->entrega, 'CPF'));
+
+        $isPickup = !empty($this->getTagValue($this->retirada, 'CNPJ'))
+            ||  !empty($this->getTagValue($this->retirada, 'CPF'));
+
+        $this->pdf->line($this->margem, $y + 2, $this->wPrint + $this->margem, $y + 2);
+        if (!$isDelivery && !$isPickup) return $y + 2;
+
+        $y += 2;
+        $texto = $isDelivery ? 'INFORMAÇÕES DO LOCAL DE ENTREGA' : 'INFORMAÇÕES DO LOCAL DE RETIRADA';
+        $aFont = ['font' => $this->fontePadrao, 'size' => 8, 'style' => 'B'];
+        $y += $this->pdf->textBox(
+            $xRs + 2,
+            $y + 2,
+            $wRs - 2,
+            $this->margem - 1,
+            $texto,
+            $aFont,
+            'T',
+            'C',
+            false,
+            '',
+            true
+        ) + 2;
+
+        $cpfMask = '###.###.###-##';
+        $cnpjMask = '###.###.###/####-##';
+        $deliveryIdentification = !empty($this->getTagValue($this->entrega, 'CNPJ'))
+            ? $this->formatField($this->getTagValue($this->entrega, 'CNPJ'), $cnpjMask)
+            : $this->formatField($this->getTagValue($this->entrega, 'CPF'), $cpfMask);
+
+        $pickupIdentification = !empty($this->getTagValue($this->retirada, 'CNPJ'))
+            ? $this->formatField($this->getTagValue($this->retirada, 'CNPJ'), $cnpjMask)
+            : $this->formatField($this->getTagValue($this->retirada, 'CPF'), $cpfMask);
+
+        $doc = $deliveryIdentification ?? $pickupIdentification;
+        $texto = "CNPJ/CPF: {$doc}";
+        $aFont = ['font' => $this->fontePadrao, 'size' => 8, 'style' => ''];
+        $y += $this->pdf->textBox(
+            $xRs + 2,
+            $y,
+            $wRs - 2,
+            $this->margem - 1,
+            $texto,
+            $aFont,
+            'T',
+            'C',
+            false,
+            '',
+            true
+        );
+
+        $xNome = !empty($this->getTagValue($this->entrega, 'xNome')) ?
+            $this->getTagValue($this->entrega, 'xNome') :
+            $this->getTagValue($this->retirada, 'xNome');
+
+        $ie = !empty($this->getTagValue($this->entrega, 'IE')) ?
+            $this->getTagValue($this->entrega, 'IE') :
+            $this->getTagValue($this->retirada, 'IE');
+
+        $xLgr = !empty($this->getTagValue($this->entrega, 'xLgr')) ?
+            $this->getTagValue($this->entrega, 'xLgr') :
+            $this->getTagValue($this->retirada, 'xLgr');
+
+        $nro = !empty($this->getTagValue($this->entrega, 'nro')) ?
+            $this->getTagValue($this->entrega, 'nro') :
+            $this->getTagValue($this->retirada, 'nro');
+
+        $xBairro = !empty($this->getTagValue($this->entrega, 'xBairro')) ?
+            $this->getTagValue($this->entrega, 'xBairro') :
+            $this->getTagValue($this->retirada, 'xBairro');
+
+        $xMun = !empty($this->getTagValue($this->entrega, 'xMun')) ?
+            $this->getTagValue($this->entrega, 'xMun') :
+            $this->getTagValue($this->retirada, 'xMun');
+
+        $uf = !empty($this->getTagValue($this->entrega, 'UF')) ?
+            $this->getTagValue($this->entrega, 'UF') :
+            $this->getTagValue($this->retirada, 'UF');
+
+        $fone = !empty($this->getTagValue($this->entrega, 'fone')) ?
+            $this->getTagValue($this->entrega, 'fone') :
+            $this->getTagValue($this->retirada, 'fone');
+
+        $email = !empty($this->getTagValue($this->entrega, 'email')) ?
+            $this->getTagValue($this->entrega, 'email') :
+            $this->getTagValue($this->retirada, 'email');
+
+        if (!empty($fone)) {
+            $fone = strlen($fone) == 11
+                ? $this->formatField($fone, "(##) #####-####")
+                : $this->formatField($fone, "(##) ####-####");
+        }
+
+        $aFont = ['font' => $this->fontePadrao, 'size' => 8, 'style' => ''];
+        $texto = "CNPJ: {$xNome} IE: {$ie}";
+        $y += $this->pdf->textBox($xRs + 2, $y, $wRs - 2, 3, $texto, $aFont, 'T', $alignH, false, '', true);
+        $texto = $xLgr . ", " . $nro;
+        $y += $this->pdf->textBox($xRs + 2, $y, $wRs - 2, 3, $texto, $aFont, 'T', $alignH, false, '', true);
+        $texto = $xBairro;
+        $y += $this->pdf->textBox($xRs + 2, $y, $wRs - 2, 3, $texto, $aFont, 'T', $alignH, false, '', true);
+
+        $texto = $xMun . "-" . $uf . ($fone ? "  Fone: " . $fone : "");
+        $y += $this->pdf->textBox($xRs + 2, $y, $wRs - 2, 3, $texto, $aFont, 'T', $alignH, false, '', true);
+        $texto = "E-mail: {$email}" ?? '';
+        $y += $this->pdf->textBox($xRs + 2, $y, $wRs - 2, 3, $texto, $aFont, 'T', $alignH, false, '', true);
+
+
+        $this->pdf->line($this->margem, $y + 2, $this->wPrint + $this->margem, $y + 2);
+        return $y + 2;
     }
 
     protected function bloco3($y)
@@ -322,14 +434,14 @@ class DanfeEtiqueta extends DaCommon
         $this->pdf->code128($x + (($this->wPrint - $bW) / 2), $y + 2, $chave_acesso, $bW, $bH);
         $texto = $this->formatField($chave_acesso, $this->formatoChave);
         $aFont = ['font' => $this->fontePadrao, 'size' => 10, 'style' => 'B'];
-        $this->pdf->textBox($x + 5, $y+ $bH +  2, $this->wPrint - 2, 7, $texto, $aFont, 'T', 'L', 0, '');
+        $this->pdf->textBox($x + 5, $y + $bH +  2, $this->wPrint - 2, 7, $texto, $aFont, 'T', 'L', 0, '');
         $y += $bH + 3;
         if (empty($this->infProt)) {
             throw new \Exception('Apenas NFe autorizadas podem ser impressas em formato de etiqueta');
         }
         if ($this->canceled) {
             throw new \Exception('Esta NFe está cancelada, e apenas NFe autorizadas podem ser '
-                .'impressas em formato de etiqueta');
+                . 'impressas em formato de etiqueta');
         }
         $protocolo  = !empty($this->nfeProc->getElementsByTagName("nProt")->item(0)->nodeValue)
             ? $this->nfeProc->getElementsByTagName("nProt")->item(0)->nodeValue
@@ -340,8 +452,8 @@ class DanfeEtiqueta extends DaCommon
         $texto .= $dtHora->format('d/m/Y H:i:s');
         $this->pdf->textBox($x, $y, $this->wPrint, 7, $texto, $aFont, 'B', 'C', 0, '');
 
-        $this->pdf->line($this->margem, $y+8, $this->wPrint+$this->margem, $y+8);
-        return $y+8;
+        $this->pdf->line($this->margem, $y + 8, $this->wPrint + $this->margem, $y + 8);
+        return $y + 8;
     }
 
     protected function bloco4($y)
@@ -352,7 +464,7 @@ class DanfeEtiqueta extends DaCommon
 
         $aFont = ['font' => $this->fontePadrao, 'size' => 9, 'style' => 'B'];
         $texto = $this->dest->getElementsByTagName("xNome")->item(0)->nodeValue;
-        $this->pdf->textBox($this->margem + 5, $y+5, $this->wPrint, 7, $texto, $aFont, 'T', 'L', 0, '');
+        $this->pdf->textBox($this->margem + 5, $y + 5, $this->wPrint, 7, $texto, $aFont, 'T', 'L', 0, '');
         $cnpj = !empty($this->dest->getElementsByTagName("CNPJ")->item(0))
             ? $this->formatField($this->dest->getElementsByTagName("CNPJ")->item(0)->nodeValue, "###.###.###/####-##")
             : null;
@@ -361,7 +473,7 @@ class DanfeEtiqueta extends DaCommon
             : null;
         $doc = $cnpj ?? $cpf;
         $texto = "CNPJ/CPF: {$doc}";
-        $this->pdf->textBox($this->margem + 5, $y+9, $this->wPrint, 7, $texto, $aFont, 'T', 'L', 0, '');
+        $this->pdf->textBox($this->margem + 5, $y + 9, $this->wPrint, 7, $texto, $aFont, 'T', 'L', 0, '');
         $ie = !empty($this->dest->getElementsByTagName("IE")->item(0))
             ? $this->formatField($this->dest->getElementsByTagName("IE")->item(0)->nodeValue, "###.###.###.###.###")
             : null;
@@ -387,10 +499,10 @@ class DanfeEtiqueta extends DaCommon
         $y += $this->pdf->textBox($this->margem + 5, $y, $this->wPrint, 3, $texto, $aFont, 'T', 'L', false, '', true);
         $texto = $destBairro;
         $y += $this->pdf->textBox($this->margem + 5, $y, $this->wPrint, 3, $texto, $aFont, 'T', 'L', false, '', true);
-        $texto = $destMun . "-" . $destUF . ($destFone ? "  Fone: ".$destFone : "");
+        $texto = $destMun . "-" . $destUF . ($destFone ? "  Fone: " . $destFone : "");
         $y += $this->pdf->textBox($this->margem + 5, $y, $this->wPrint, 3, $texto, $aFont, 'T', 'L', false, '', true);
-        $this->pdf->line($this->margem, $y+2, $this->wPrint+$this->margem, $y+2);
-        return $y+2;
+        $this->pdf->line($this->margem, $y + 2, $this->wPrint + $this->margem, $y + 2);
+        return $y + 2;
     }
 
     protected function bloco5($y)
@@ -399,8 +511,8 @@ class DanfeEtiqueta extends DaCommon
         $texto = "Valor TOTAL da NFe: R$ $total";
         $aFont = ['font' => $this->fontePadrao, 'size' => 10, 'style' => 'B'];
         $y += $this->pdf->textBox($this->margem, $y, $this->wPrint, 6, $texto, $aFont, 'C', 'C', false, '', true);
-        $this->pdf->line($this->margem, $y+3, $this->wPrint+$this->margem, $y+2);
-        return $y+2;
+        $this->pdf->line($this->margem, $y + 3, $this->wPrint + $this->margem, $y + 2);
+        return $y + 2;
     }
 
     protected function bloco6($y)
@@ -410,8 +522,8 @@ class DanfeEtiqueta extends DaCommon
             $texto = "PEDIDO: $pedido";
             $aFont = ['font' => $this->fontePadrao, 'size' => 10, 'style' => 'B'];
             $y += $this->pdf->textBox(
-                $this->margem+1,
-                $y+2,
+                $this->margem + 1,
+                $y + 2,
                 $this->wPrint,
                 6,
                 $texto,
@@ -425,13 +537,13 @@ class DanfeEtiqueta extends DaCommon
         }
         $texto = "Informações Complementares:";
         $aFont = ['font' => $this->fontePadrao, 'size' => 8, 'style' => 'I'];
-        $y += $this->pdf->textBox($this->margem+1, $y+4, $this->wPrint, 6, $texto, $aFont, 'T', 'L', false, '', false);
+        $y += $this->pdf->textBox($this->margem + 1, $y + 4, $this->wPrint, 6, $texto, $aFont, 'T', 'L', false, '', false);
         $texto = $this->infCpl . "\n" . $this->infAdFisco;
         $aFont = ['font' => $this->fontePadrao, 'size' => 9, 'style' => ''];
         $y += $this->pdf->textBox(
-            $this->margem+1,
-            $y+5,
-            $this->wPrint-2,
+            $this->margem + 1,
+            $y + 5,
+            $this->wPrint - 2,
             6,
             $texto,
             $aFont,
@@ -474,6 +586,8 @@ class DanfeEtiqueta extends DaCommon
         $this->infAdic = $this->dom->getElementsByTagName("infAdic")->item(0);
         $this->tpEmis = $this->dom->getValue($this->ide, "tpEmis");
         $this->compra = $this->infNFe->getElementsByTagName("compra")->item(0);
+        $this->entrega = $this->dom->getElementsByTagName("entrega")->item(0) ?? null;
+        $this->retirada = $this->dom->getElementsByTagName("retirada")->item(0) ?? null;
         $this->infCpl = '';
         if (!empty($this->infAdic)) {
             if (!empty($this->infAdic->getElementsByTagName("infCpl")->item(0))) {
@@ -494,12 +608,12 @@ class DanfeEtiqueta extends DaCommon
         }
         if (!empty($this->infProt)) {
             $cStat = $this->getTagValue($this->infProt, 'cStat');
-            if (!in_array($cStat, [100,150])) {
+            if (!in_array($cStat, [100, 150])) {
                 $this->canceled = true;
             } elseif (!empty($retEvento = $this->nfeProc->getElementsByTagName('retEvento')->item(0))) {
                 $infEvento = $retEvento->getElementsByTagName('infEvento')->item(0);
                 $cStat = $this->getTagValue($infEvento, "cStat");
-                $tpEvento= $this->getTagValue($infEvento, "tpEvento");
+                $tpEvento = $this->getTagValue($infEvento, "tpEvento");
                 $dhEvento = date(
                     "d/m/Y H:i:s",
                     $this->toTimestamp(

--- a/src/NFe/DanfeSimples.php
+++ b/src/NFe/DanfeSimples.php
@@ -604,6 +604,8 @@ class DanfeSimples extends DaCommon
             10 => fn() => preg_replace('/(\d{2})(\d{4})(\d{4})/', '($1) $2-$3', $phone)
         ];
 
-        return $acceptsPhoneLength[strlen($phone)]() ?? $phone;
+        return !empty($acceptsPhoneLength[strlen($phone)]) ?
+            $acceptsPhoneLength[strlen($phone)]() :
+            $phone;
     }
 }

--- a/src/NFe/DanfeSimples.php
+++ b/src/NFe/DanfeSimples.php
@@ -2,6 +2,7 @@
 /*
  * Author Newton Pasqualini Filho (newtonpasqualini at gmail dot com)
  */
+
 namespace NFePHP\DA\NFe;
 
 use NFePHP\DA\Legacy\Dom;
@@ -202,7 +203,7 @@ class DanfeSimples extends DaCommon
             $json = json_encode($stdClass, JSON_OBJECT_AS_ARRAY);
             $this->nfeArray = json_decode($json, JSON_OBJECT_AS_ARRAY);
             if (!isset($this->nfeArray['NFe']['infNFe']['@attributes']['Id'])) {
-                throw new \Exception('XML não parece ser uma NF-e!');
+                throw new \Exception('XML não parece ser uma NF-e ou não está autorizado!');
             }
             if ($this->nfeArray['protNFe']['infProt']['cStat'] != '100') {
                 throw new \Exception('NF-e não autorizada!');
@@ -289,7 +290,7 @@ class DanfeSimples extends DaCommon
         }
 
         // LINHA 1
-        $this->pdf->setFont('Arial', 'B', $pequeno ? 10 : 12);
+        $this->pdf->setFont('times', 'B', $pequeno ? 10 : 12);
         $this->pdf->cell(
             ($this->maxW - ($this->margesq * 2)),
             $pequeno ? 5 : 6,
@@ -303,45 +304,45 @@ class DanfeSimples extends DaCommon
         // LINHA 2
         $dataEmissao = date('d/m/Y', strtotime("{$this->nfeArray['NFe']['infNFe']['ide']['dhEmi']}"));
         $c1 = ($this->maxW - ($this->margesq * 2)) / 4;
-        $this->pdf->setFont('Arial', 'B', $pequeno ? 8 : 10);
+        $this->pdf->setFont('times', 'B', $pequeno ? 8 : 10);
         $this->pdf->cell($c1, $pequeno ? 4 : 5, "TIPO NF", 1, 0, 'C', 1);
-        $this->pdf->setFont('Arial', '', 10);
+        $this->pdf->setFont('times', '', 10);
         $this->pdf->cell(
             $c1,
             5,
             "{$this->nfeArray['NFe']['infNFe']['ide']['tpNF']} - " .
-                                  ($this->nfeArray['NFe']['infNFe']['ide']['tpNF']==1 ? 'Saida':'Entrada'),
+                ($this->nfeArray['NFe']['infNFe']['ide']['tpNF'] == 1 ? 'Saida' : 'Entrada'),
             1,
             0,
             'C',
             1
         );
-        $this->pdf->setFont('Arial', 'B', $pequeno ? 8 : 10);
+        $this->pdf->setFont('times', 'B', $pequeno ? 8 : 10);
         $this->pdf->cell($c1, $pequeno ? 4 : 5, "DATA EMISSAO", 1, 0, 'C', 1);
-        $this->pdf->setFont('Arial', '', 10);
+        $this->pdf->setFont('times', '', 10);
         $this->pdf->cell($c1, $pequeno ? 4 : 5, "{$dataEmissao}", 1, 1, 'C', 1);
 
         // LINHA 3
-        $this->pdf->setFont('Arial', 'B', $pequeno ? 8 : 10);
+        $this->pdf->setFont('times', 'B', $pequeno ? 8 : 10);
         $this->pdf->cell($c1, $pequeno ? 4 : 5, "NUMERO", 1, 0, 'C', 1);
-        $this->pdf->setFont('Arial', '', 10);
+        $this->pdf->setFont('times', '', 10);
         $this->pdf->cell($c1, $pequeno ? 4 : 5, "{$this->nfeArray['NFe']['infNFe']['ide']['nNF']}", 1, 0, 'C', 1);
-        $this->pdf->setFont('Arial', 'B', $pequeno ? 8 : 10);
+        $this->pdf->setFont('times', 'B', $pequeno ? 8 : 10);
         $this->pdf->cell($c1, $pequeno ? 4 : 5, "SERIE", 1, 0, 'C', 1);
-        $this->pdf->setFont('Arial', '', 10);
+        $this->pdf->setFont('times', '', 10);
         $this->pdf->cell($c1, $pequeno ? 4 : 5, "{$this->nfeArray['NFe']['infNFe']['ide']['serie']}", 1, 1, 'C', 1);
 
         // LINHA 4
         $chave = substr($this->nfeArray['NFe']['infNFe']['@attributes']['Id'], 3);
-        $this->pdf->setFont('Arial', 'B', $pequeno ? 7 : 10);
+        $this->pdf->setFont('times', 'B', $pequeno ? 7 : 10);
         $this->pdf->cell($c1, $pequeno ? 4 : 5, "CHAVE DE ACESSO", 1, 0, 'C', 1);
-        $this->pdf->setFont('Arial', '', $pequeno ? 8 : 10);
+        $this->pdf->setFont('times', '', $pequeno ? 8 : 10);
         $this->pdf->cell(($c1 * 3), $pequeno ? 4 : 5, "{$chave}", 1, 1, 'C', 1);
 
         // LINHA 5
-        $this->pdf->setFont('Arial', 'B', $pequeno ? 8 : 10);
+        $this->pdf->setFont('times', 'B', $pequeno ? 8 : 10);
         $this->pdf->cell($c1, $pequeno ? 4 : 5, "PROTOCOLO", 1, 0, 'C', 1);
-        $this->pdf->setFont('Arial', '', 10);
+        $this->pdf->setFont('times', '', 10);
         $dataProto = date("d/m/Y H:i:s", strtotime($this->nfeArray['protNFe']['infProt']['dhRecbto']));
         $this->pdf->cell(
             ($c1 * 3),
@@ -361,7 +362,7 @@ class DanfeSimples extends DaCommon
             //que uma impressora de 203dpi consiga imprimir um código legível
             $this->pdf->code128($this->margesq * 2, $y, $chave, ($this->maxW - $this->margesq * 4), 15);
         } else {
-            $this->pdf->code128(($c1/2), $y, $chave, ($c1 * 3), 15);
+            $this->pdf->code128(($c1 / 2), $y, $chave, ($c1 * 3), 15);
         }
         $this->pdf->setFillColor(255, 255, 255);
         $this->pdf->ln();
@@ -371,11 +372,11 @@ class DanfeSimples extends DaCommon
         $this->pdf->ln();
 
         // LINHA 6
-        $this->pdf->setFont('Arial', 'B', $pequeno ? 10 : 12);
+        $this->pdf->setFont('times', 'B', $pequeno ? 10 : 12);
         $this->pdf->cell(($c1 * 4), $pequeno ? 5 : 6, "EMITENTE", 1, 1, 'C', 1);
 
         // LINHA 7
-        $this->pdf->setFont('Arial', '', $pequeno ? 9 : 10);
+        $this->pdf->setFont('times', '', $pequeno ? 9 : 10);
         $this->pdf->multiCell(
             ($c1 * 4),
             $pequeno ? 4 : 5,
@@ -388,7 +389,7 @@ class DanfeSimples extends DaCommon
         // LINHA 8
         $cpfCnpj = (isset($this->nfeArray['NFe']['infNFe']['emit']['CNPJ'])
             ? $this->nfeArray['NFe']['infNFe']['emit']['CNPJ']
-            :$this->nfeArray['NFe']['infNFe']['emit']['CPF']);
+            : $this->nfeArray['NFe']['infNFe']['emit']['CPF']);
         $this->pdf->cell(($c1 * 2), $pequeno ? 4 : 5, "CNPJ/CPF {$cpfCnpj}", 1, 0, 'C', 1);
         $this->pdf->cell(
             ($c1 * 2),
@@ -401,19 +402,19 @@ class DanfeSimples extends DaCommon
         );
 
         $enderecoEmit  = "{$this->nfeArray['NFe']['infNFe']['emit']['enderEmit']['xMun']}"
-                       . " / {$this->nfeArray['NFe']['infNFe']['emit']['enderEmit']['UF']}"
-                       . " - CEP {$this->nfeArray['NFe']['infNFe']['emit']['enderEmit']['CEP']}";
+            . " / {$this->nfeArray['NFe']['infNFe']['emit']['enderEmit']['UF']}"
+            . " - CEP {$this->nfeArray['NFe']['infNFe']['emit']['enderEmit']['CEP']}";
 
         // LINHA 9
-        $this->pdf->setFont('Arial', '', $pequeno ? 9 : 10);
+        $this->pdf->setFont('times', '', $pequeno ? 9 : 10);
         $this->pdf->cell(($c1 * 4), $pequeno ? 4 : 5, "{$enderecoEmit}", 1, 1, 'C', 1);
 
         // LINHA 10
-        $this->pdf->setFont('Arial', 'B', $pequeno ? 10 : 12);
+        $this->pdf->setFont('times', 'B', $pequeno ? 10 : 12);
         $this->pdf->cell(($c1 * 4), $pequeno ? 5 : 6, "DESTINATARIO", 1, 1, 'C', 1);
 
         // LINHA 11
-        $this->pdf->setFont('Arial', '', $pequeno ? 9 : 10);
+        $this->pdf->setFont('times', '', $pequeno ? 9 : 10);
         $this->pdf->multiCell(
             ($c1 * 4),
             $pequeno ? 4 : 5,
@@ -426,7 +427,7 @@ class DanfeSimples extends DaCommon
         // LINHA 12
         $cpfCnpj = (isset($this->nfeArray['NFe']['infNFe']['dest']['CNPJ'])
             ? $this->nfeArray['NFe']['infNFe']['dest']['CNPJ']
-            :$this->nfeArray['NFe']['infNFe']['dest']['CPF']);
+            : $this->nfeArray['NFe']['infNFe']['dest']['CPF']);
         $this->pdf->cell(($c1 * 2), $pequeno ? 4 : 5, "CNPJ/CPF {$cpfCnpj}", 1, 0, 'C', 1);
         $this->pdf->cell(
             ($c1 * 2),
@@ -438,44 +439,31 @@ class DanfeSimples extends DaCommon
             1
         );
 
-        if (isset($this->nfeArray['NFe']['infNFe']['entrega'])) {
-            $enderecoLinha1 = "{$this->nfeArray['NFe']['infNFe']['entrega']['xLgr']}";
-            if (!empty($this->nfeArray['NFe']['infNFe']['entrega']['nro'])) {
-                $enderecoLinha1 .= ", {$this->nfeArray['NFe']['infNFe']['entrega']['nro']}";
-            }
-            $enderecoLinha2 = '';
-            if (!empty($this->nfeArray['NFe']['infNFe']['entrega']['xCpl'])) {
-                $enderecoLinha2 .= "{$this->nfeArray['NFe']['infNFe']['entrega']['xCpl']} - ";
-            }
-            $enderecoLinha2 .= "{$this->nfeArray['NFe']['infNFe']['entrega']['xMun']}"
-                             . " / {$this->nfeArray['NFe']['infNFe']['entrega']['UF']}"
-                             . " - CEP {$this->nfeArray['NFe']['infNFe']['entrega']['CEP']}";
-        } else {
-            $enderecoLinha1 = "{$this->nfeArray['NFe']['infNFe']['dest']['enderDest']['xLgr']}";
-            if (!empty($this->nfeArray['NFe']['infNFe']['dest']['enderDest']['nro'])) {
-                $enderecoLinha1 .= ", {$this->nfeArray['NFe']['infNFe']['dest']['enderDest']['nro']}";
-            }
-            $enderecoLinha2 = '';
-            if (!empty($this->nfeArray['NFe']['infNFe']['dest']['enderDest']['xCpl'])) {
-                $enderecoLinha2 .= "{$this->nfeArray['NFe']['infNFe']['dest']['enderDest']['xCpl']} - ";
-            }
-            $enderecoLinha2 .= "{$this->nfeArray['NFe']['infNFe']['dest']['enderDest']['xMun']}"
-                             . " / {$this->nfeArray['NFe']['infNFe']['dest']['enderDest']['UF']}"
-                             . " - CEP {$this->nfeArray['NFe']['infNFe']['dest']['enderDest']['CEP']}";
+        $enderecoLinha1 = "{$this->nfeArray['NFe']['infNFe']['dest']['enderDest']['xLgr']}";
+        if (!empty($this->nfeArray['NFe']['infNFe']['dest']['enderDest']['nro'])) {
+            $enderecoLinha1 .= ", {$this->nfeArray['NFe']['infNFe']['dest']['enderDest']['nro']}";
         }
+        $enderecoLinha2 = '';
+        if (!empty($this->nfeArray['NFe']['infNFe']['dest']['enderDest']['xCpl'])) {
+            $enderecoLinha2 .= "{$this->nfeArray['NFe']['infNFe']['dest']['enderDest']['xCpl']} - ";
+        }
+        $enderecoLinha2 .= "{$this->nfeArray['NFe']['infNFe']['dest']['enderDest']['xMun']}"
+            . " / {$this->nfeArray['NFe']['infNFe']['dest']['enderDest']['UF']}"
+            . " - CEP {$this->nfeArray['NFe']['infNFe']['dest']['enderDest']['CEP']}";
 
-        $this->pdf->setFont('Arial', '', $pequeno ? 9 : 10);
+        $this->pdf->setFont('times', '', $pequeno ? 9 : 10);
         $this->pdf->cell(($c1 * 4), $pequeno ? 4 : 5, "{$enderecoLinha1}", 1, 1, 'C', 1);
 
-        $this->pdf->setFont('Arial', '', $pequeno ? 9 : 10);
+        $this->pdf->setFont('times', '', $pequeno ? 9 : 10);
         $this->pdf->cell(($c1 * 4), $pequeno ? 4 : 5, "{$enderecoLinha2}", 1, 1, 'C', 1);
 
-        if ($this->nfeArray['NFe']['infNFe']['transp']['modFrete'] != 9
+        if (
+            $this->nfeArray['NFe']['infNFe']['transp']['modFrete'] != 9
             && isset($this->nfeArray['NFe']['infNFe']['transp']['transporta'])
         ) {
-            $this->pdf->setFont('Arial', 'B', $pequeno ? 10 : 12);
+            $this->pdf->setFont('times', 'B', $pequeno ? 10 : 12);
             $this->pdf->cell(($c1 * 4), $pequeno ? 5 : 6, "TRANSPORTADORA", 1, 1, 'C', 1);
-            $this->pdf->setFont('Arial', '', $pequeno ? 9 : 10);
+            $this->pdf->setFont('times', '', $pequeno ? 9 : 10);
             $this->pdf->cell(
                 ($c1 * 4),
                 $pequeno ? 5 : 6,
@@ -514,16 +502,16 @@ class DanfeSimples extends DaCommon
             1
         );
 
-        $this->pdf->setFont('Arial', 'B', $pequeno ? 10 : 12);
+        $this->pdf->setFont('times', 'B', $pequeno ? 10 : 12);
         $this->pdf->cell(($c1 * 2), $pequeno ? 5 : 6, "TOTAL DA NF-e", 1, 0, 'C', 1);
-        $this->pdf->setFont('Arial', '', $pequeno ? 8 : 10);
+        $this->pdf->setFont('times', '', $pequeno ? 8 : 10);
         $vNF = number_format($this->nfeArray['NFe']['infNFe']['total']['ICMSTot']['vNF'], 2, ',', '.');
         $this->pdf->cell(($c1 * 2), $pequeno ? 5 : 6, "R$ {$vNF}", 1, 1, 'C', 1);
 
         if (isset($this->nfeArray['NFe']['infNFe']['infAdic'])) {
-            $this->pdf->setFont('Arial', 'B', $pequeno ? 10 : 12);
+            $this->pdf->setFont('times', 'B', $pequeno ? 10 : 12);
             $this->pdf->cell(($c1 * 4), $pequeno ? 5 : 6, "DADOS ADICIONAIS", 1, 1, 'C', 1);
-            $this->pdf->setFont('Arial', '', $pequeno ? 8 : 10);
+            $this->pdf->setFont('times', '', $pequeno ? 8 : 10);
             $this->pdf->multiCell(
                 ($c1 * 4),
                 $pequeno ? 3 : 5,
@@ -534,5 +522,88 @@ class DanfeSimples extends DaCommon
                 1
             );
         }
+
+        $entrega = $this->nfeArray['NFe']['infNFe']['entrega'] ?? null;
+        $retirada = $this->nfeArray['NFe']['infNFe']['retirada'] ?? null;
+        if (empty($entrega) && empty($retirada)) return;
+
+        $this->pdf->ln();
+        $this->pdf->ln();
+
+        $isDelivery = !empty($entrega);
+        $label = $isDelivery ?  'INFORMACOES DO LOCAL DE ENTREGA' : 'INFORMACOES DO LOCAL DE RETIRADA';
+        $this->pdf->setFont('times', 'B', $pequeno ? 10 : 12);
+        $this->pdf->cell(
+            ($this->maxW - ($this->margesq * 2)),
+            $pequeno ? 5 : 6,
+            $label,
+            1,
+            1,
+            'C',
+            1
+        );
+
+        $companyName = $isDelivery ? $entrega['xNome'] : $retirada['xNome'];
+        $this->pdf->setFont('times', '', $pequeno ? 9 : 10);
+        $this->pdf->cell(($c1 * 2), $pequeno ? 4 : 5, $companyName, 1, 0, 'C', 1);
+        $ie = $isDelivery ? $entrega['IE'] : $retirada['IE'];
+        $fone = $isDelivery ? $entrega['fone'] : $retirada['fone'];
+        $fone = empty($fone) ?: $this->formatPhone($fone);
+
+        $this->pdf->cell(
+            ($c1 * 2),
+            $pequeno ? 4 : 5,
+            $fone,
+            1,
+            1,
+            'C',
+            1
+        );
+
+        $cpfCnpj = $isDelivery
+            ? ($entrega['CNPJ'] ?? $entrega['CPF'])
+            : ($retirada['CNPJ'] ?? $retirada['CPF']);
+
+        $this->pdf->cell(($c1 * 2), $pequeno ? 4 : 5, "CNPJ/CPF {$cpfCnpj}", 1, 0, 'C', 1);
+        $ie = $isDelivery ? $entrega['IE'] : $retirada['IE'];
+
+        $this->pdf->cell(
+            ($c1 * 2),
+            $pequeno ? 4 : 5,
+            @"RG/IE {$ie}",
+            1,
+            1,
+            'C',
+            1
+        );
+
+        $xLgr = $isDelivery ? $entrega['xLgr'] : $retirada['xLgr'];
+        $nro = $isDelivery ? $entrega['nro'] : $retirada['nro'];
+        $logradAndNumber = sprintf('%s, %s', $xLgr, $nro);
+
+        $this->pdf->setFont('times', '', $pequeno ? 9 : 10);
+        $this->pdf->cell(($c1 * 4), $pequeno ? 4 : 5, $logradAndNumber, 1, 1, 'C', 1);
+
+        $xCpl = $isDelivery ? $entrega['xCpl'] . ' - ' : $retirada['xCpl'] . ' - ';
+        $xMun = $isDelivery ? $entrega['xMun'] : $retirada['xMun'];
+        $uf = $isDelivery ? $entrega['UF'] : $retirada['UF'];
+        $cep = $isDelivery ? $entrega['CEP'] : $retirada['CEP'];
+
+        $deliveryAddress = sprintf('%s%s / %s - CEP %s', $xCpl ?? '', $xMun ?? '', $uf ?? '', $cep ?? ' ');
+
+        $this->pdf->setFont('times', '', $pequeno ? 9 : 10);
+        $this->pdf->cell(($c1 * 4), $pequeno ? 4 : 5, $deliveryAddress, 1, 1, 'C', 1);
+    }
+
+    protected function formatPhone($phone)
+    {
+        if (!$phone) return null;
+        $phone = preg_replace('/\D+/', '', $phone);
+        $acceptsPhoneLength = [
+            11 => fn() => preg_replace('/(\d{2})(\d{5})(\d{4})/', '($1) $2-$3', $phone),
+            10 => fn() => preg_replace('/(\d{2})(\d{4})(\d{4})/', '($1) $2-$3', $phone)
+        ];
+
+        return $acceptsPhoneLength[strlen($phone)]() ?? $phone;
     }
 }


### PR DESCRIPTION
https://zucchettibr.atlassian.net/browse/WEB-2573

<div class="panel" style="background-color: #deebff;border-width: 1px;"><div class="panelContent" style="background-color: #deebff;">
<p><b>Solicitação Aceita <span class="error">&#91;Análise&#93;</span></b></p>

<p> <b>HIST001:</b>  Ao emitir uma NF-e onde seja selecionado o local de entrega diferente do endereço do cliente, o sistema esta alterando o endereço do destinatário.  Segundo orientação das contabilidades o correto é que o endereço do destinatário não seja alterado e sim que o local de entrega seja impresso na observação.</p>
</div></div>

<div class="panel" style="background-color: #fffae6;border-width: 1px;"><div class="panelContent" style="background-color: #fffae6;">
<p> <b>Regras de negócio <span class="error">&#91;Product Owner&#93;</span></b> </p>

<p><b>RN001:</b> Opção deverá ser implementada somente no Zetaweb</p>
</div></div>

<div class="panel" style="background-color: #eae6ff;border-width: 1px;"><div class="panelContent" style="background-color: #eae6ff;">
<p><b>Requisitos funcionais ou não funcionais <span class="error">&#91;Product Owner &amp; Dev&#93;</span></b> </p>

<p><b>RF001</b>: Adicionar função de Endereço de Entrega e Endereço de Retidada no modal de Destinatário, permitindo assim a indicação de um outro cliente ou até mesmo o próprio cliente com o endereço de entrega.</p>

<p>RF002: As duas opções deverão ficar como padrão recolhidas, devendo só ficar ativa, após a informação de um cliente no Destinatário.</p>

<p><span class="image-wrap" style=""><img src="/rest/api/3/attachment/content/20537" alt="image-20240919-165651.png" width="91.66666666666666%" style="border: 0px solid black" /></span></p>

<p>RF003: Ao clicar em Endereço de entrega  ou Endereço de retirada, deverá extender o mesmo modal, para ser possível indicar uma das opções.</p>

<p><span class="image-wrap" style=""><img src="/rest/api/3/attachment/content/20538" alt="image-20240919-165835.png" width="91.66666666666666%" style="border: 0px solid black" /></span></p>

<p>RF004: Para o Endereço de entrega, deverá ser possível pesquisar clientes e após a indicação do mesmo, escolher endereços cadastrados para o mesmo, assim como o telefone.</p>

<p>RF005: Deverá também ser permitido, cadastrar e editar o registro indicado. </p>

<p>RF006: Deverá também ter a opção de remover ( x ) ao lado do campo de telefone, sendo assim quando utilizado, deverá remover os campos de cliente e consequentemente seus dados.</p>

<p>RF007: Ao ser informado deverá ser preenchido a tag &lt;entrega&gt; do documento, com os respectivos dados informados.</p>

<p><span class="image-wrap" style=""><img src="/rest/api/3/attachment/content/20132" alt="image-20240909-181329.png" height="228" width="467" style="border: 0px solid black" /></span></p>

<p>RF008: Quando existir a tag preenchida, deverá ser feito a geração também no DANFE impresso ( conferir nos modelos etiqueta e etiqueta simplificada)</p>

<p><span class="image-wrap" style=""><img src="/rest/api/3/attachment/content/20535" alt="image-20240919-170215.png" width="91.66666666666666%" style="border: 0px solid black" /></span></p>
</div></div>

<div class="panel" style="background-color: #eae6ff;border-width: 1px;"><div class="panelContent" style="background-color: #eae6ff;">
<p>RF009: Para o Endereço de retirada, deverá ser possível pesquisar Fornecedores e após a indicação do mesmo, escolher endereços cadastrados para o mesmo, assim como o telefone.</p>

<p>RF010: Deverá também ser permitido, cadastrar e editar o registro indicado. </p>

<p>RF011: Deverá também ter a opção de remover ( x ) ao lado do campo de telefone, sendo assim quando utilizado, deverá remover os campos do fornecedor e consequentemente seus dados.</p>

<p>RF012: Ao ser informado deverá ser preenchido a tag &lt;entrega&gt; do documento, com os respectivos dados informados.</p>

<p><span class="image-wrap" style=""><img src="/rest/api/3/attachment/content/20131" alt="image-20240909-181257.png" height="234" width="320" style="border: 0px solid black" /></span></p>

<p>RF013: Quando existir a tag preenchida, deverá ser feito a geração também no DANFE impresso ( conferir nos modelos etiqueta e etiqueta simplificada)</p>

<p><span class="image-wrap" style=""><img src="/rest/api/3/attachment/content/20536" alt="image-20240919-170412.png" width="91.66666666666666%" style="border: 0px solid black" /></span></p>

<p>RF014: Ao informar um Cliente de UF &gt;&lt; do emitente, deverá respeitar UF do cliente informado no Endereço de entrega e seguindo como base a UF do mesmo para calculos de impostos e CFOP.</p>

<p>RF0015: Implementar para A4 e Etiquetas.</p>
</div></div>

<div class="panel" style="background-color: #e3fcef;border-width: 1px;"><div class="panelContent" style="background-color: #e3fcef;">
<p> <b>Critérios de aceitação <span class="error">&#91;Product Owner &amp; Tester&#93;</span></b> </p>

<p>O projeto será considerado aprovado pelo time de qualidade quando forem atendidos os seguintes critérios de aceitação:  </p>

<ul>
	<li>Layout for atendido conforme proprosto por UI</li>
	<li>Ser possível selecionar um cliente e seu endereço -Estadual e Interestadual</li>
	<li>Ser possível selecionar um fornecedor e seu endereço - Estadual e Interestadual</li>
	<li>XML e Danfe estarem corretos.</li>
	<li>RF014 estar correta e validada.</li>
</ul>
</div></div>