### PR TITLE
WEB-2573 - 20869 - Local de entrega para emissão de NF-e.

### DIFF
--- a/src/NFe/DanfeEtiqueta.php
+++ b/src/NFe/DanfeEtiqueta.php
@@ -406,7 +406,7 @@ class DanfeEtiqueta extends DaCommon
         }
 
         $aFont = ['font' => $this->fontePadrao, 'size' => 8, 'style' => ''];
-        $texto = "CNPJ: {$xNome} IE: {$ie}";
+        $texto = "{$xNome} IE: {$ie}";
         $y += $this->pdf->textBox($xRs + 2, $y, $wRs - 2, 3, $texto, $aFont, 'T', $alignH, false, '', true);
         $texto = $xLgr . ", " . $nro;
         $y += $this->pdf->textBox($xRs + 2, $y, $wRs - 2, 3, $texto, $aFont, 'T', $alignH, false, '', true);

--- a/src/NFe/DanfeSimples.php
+++ b/src/NFe/DanfeSimples.php
@@ -548,7 +548,7 @@ class DanfeSimples extends DaCommon
         $this->pdf->cell(($c1 * 2), $pequeno ? 4 : 5, $companyName, 1, 0, 'C', 1);
         $ie = $isDelivery ? $entrega['IE'] : $retirada['IE'];
         $fone = $isDelivery ? $entrega['fone'] : $retirada['fone'];
-        $fone = empty($fone) ?: $this->formatPhone($fone);
+        $fone = empty($fone) ? null : $this->formatPhone($fone);
 
         $this->pdf->cell(
             ($c1 * 2),
@@ -597,7 +597,7 @@ class DanfeSimples extends DaCommon
 
     protected function formatPhone($phone)
     {
-        if (!$phone) return null;
+        if (!$phone || strlen($phone) < 8) return null;
         $phone = preg_replace('/\D+/', '', $phone);
         $acceptsPhoneLength = [
             11 => fn() => preg_replace('/(\d{2})(\d{5})(\d{4})/', '($1) $2-$3', $phone),


### PR DESCRIPTION
https://zucchettibr.atlassian.net/browse/WEB-2573

<div class="panel" style="background-color: #deebff;border-width: 1px;"><div class="panelContent" style="background-color: #deebff;">
<p><b>Solicitação Aceita <span class="error">&#91;Análise&#93;</span></b></p>

<p> <b>HIST001:</b>  Ao emitir uma NF-e onde seja selecionado o local de entrega diferente do endereço do cliente, o sistema esta alterando o endereço do destinatário.  Segundo orientação das contabilidades o correto é que o endereço do destinatário não seja alterado e sim que o local de entrega seja impresso na observação.</p>
</div></div>

<div class="panel" style="background-color: #fffae6;border-width: 1px;"><div class="panelContent" style="background-color: #fffae6;">
<p> <b>Regras de negócio <span class="error">&#91;Product Owner&#93;</span></b> </p>

<p><b>RN001:</b> Opção deverá ser implementada somente no Zetaweb</p>
</div></div>

<div class="panel" style="background-color: #eae6ff;border-width: 1px;"><div class="panelContent" style="background-color: #eae6ff;">
<p><b>Requisitos funcionais ou não funcionais <span class="error">&#91;Product Owner &amp; Dev&#93;</span></b> </p>

<p><b>RF001</b>: Adicionar função de Endereço de Entrega e Endereço de Retidada no modal de Destinatário, permitindo assim a indicação de um outro cliente ou até mesmo o próprio cliente com o endereço de entrega.</p>

<p>RF002: As duas opções deverão ficar como padrão recolhidas, devendo só ficar ativa, após a informação de um cliente no Destinatário.</p>

<p><span class="image-wrap" style=""><img src="/rest/api/3/attachment/content/20537" alt="image-20240919-165651.png" width="91.66666666666666%" style="border: 0px solid black" /></span></p>

<p>RF003: Ao clicar em Endereço de entrega  ou Endereço de retirada, deverá extender o mesmo modal, para ser possível indicar uma das opções.</p>

<p><span class="image-wrap" style=""><img src="/rest/api/3/attachment/content/20538" alt="image-20240919-165835.png" width="91.66666666666666%" style="border: 0px solid black" /></span></p>

<p>RF004: Para o Endereço de entrega, deverá ser possível pesquisar clientes e após a indicação do mesmo, escolher endereços cadastrados para o mesmo, assim como o telefone.</p>

<p>RF005: Deverá também ser permitido, cadastrar e editar o registro indicado. </p>

<p>RF006: Deverá também ter a opção de remover ( x ) ao lado do campo de telefone, sendo assim quando utilizado, deverá remover os campos de cliente e consequentemente seus dados.</p>

<p>RF007: Ao ser informado deverá ser preenchido a tag &lt;entrega&gt; do documento, com os respectivos dados informados.</p>

<p><span class="image-wrap" style=""><img src="/rest/api/3/attachment/content/20132" alt="image-20240909-181329.png" height="228" width="467" style="border: 0px solid black" /></span></p>

<p>RF008: Quando existir a tag preenchida, deverá ser feito a geração também no DANFE impresso ( conferir nos modelos etiqueta e etiqueta simplificada)</p>

<p><span class="image-wrap" style=""><img src="/rest/api/3/attachment/content/20535" alt="image-20240919-170215.png" width="91.66666666666666%" style="border: 0px solid black" /></span></p>
</div></div>

<div class="panel" style="background-color: #eae6ff;border-width: 1px;"><div class="panelContent" style="background-color: #eae6ff;">
<p>RF009: Para o Endereço de retirada, deverá ser possível pesquisar Fornecedores e após a indicação do mesmo, escolher endereços cadastrados para o mesmo, assim como o telefone.</p>

<p>RF010: Deverá também ser permitido, cadastrar e editar o registro indicado. </p>

<p>RF011: Deverá também ter a opção de remover ( x ) ao lado do campo de telefone, sendo assim quando utilizado, deverá remover os campos do fornecedor e consequentemente seus dados.</p>

<p>RF012: Ao ser informado deverá ser preenchido a tag &lt;entrega&gt; do documento, com os respectivos dados informados.</p>

<p><span class="image-wrap" style=""><img src="/rest/api/3/attachment/content/20131" alt="image-20240909-181257.png" height="234" width="320" style="border: 0px solid black" /></span></p>

<p>RF013: Quando existir a tag preenchida, deverá ser feito a geração também no DANFE impresso ( conferir nos modelos etiqueta e etiqueta simplificada)</p>

<p><span class="image-wrap" style=""><img src="/rest/api/3/attachment/content/20536" alt="image-20240919-170412.png" width="91.66666666666666%" style="border: 0px solid black" /></span></p>

<p>RF014: Ao informar um Cliente de UF &gt;&lt; do emitente, deverá respeitar UF do cliente informado no Endereço de entrega e seguindo como base a UF do mesmo para calculos de impostos e CFOP.</p>

<p>RF0015: Implementar para A4 e Etiquetas.</p>
</div></div>

<div class="panel" style="background-color: #e3fcef;border-width: 1px;"><div class="panelContent" style="background-color: #e3fcef;">
<p> <b>Critérios de aceitação <span class="error">&#91;Product Owner &amp; Tester&#93;</span></b> </p>

<p>O projeto será considerado aprovado pelo time de qualidade quando forem atendidos os seguintes critérios de aceitação:  </p>

<ul>
	<li>Layout for atendido conforme proprosto por UI</li>
	<li>Ser possível selecionar um cliente e seu endereço -Estadual e Interestadual</li>
	<li>Ser possível selecionar um fornecedor e seu endereço - Estadual e Interestadual</li>
	<li>XML e Danfe estarem corretos.</li>
	<li>RF014 estar correta e validada.</li>
</ul>
</div></div>