### PR TITLE
WEB-3642 - 22111 - Ao gerar visualização de um MDF-e Data e hora de emissão estão desalinhados

### DIFF
--- a/src/MDFe/Damdfe.php
+++ b/src/MDFe/Damdfe.php
@@ -704,8 +704,7 @@ class Damdfe extends DaCommon
         $texto = 'Data e Hora de Emissão';
         $aFont = array('font' => $this->fontePadrao, 'size' => 8, 'style' => '');
         $this->pdf->textBox($x1, $y, $x3 - 1, 8, $texto, $aFont, 'T', 'L', 0, '', false);
-        $data = explode('T', $this->dhEmi);
-        $texto = $this->ymdTodmy($data[0]) . ' - ' . $data[1];
+        $texto = date('d/m/Y - H:i:s', strtotime($this->dhEmi));
         $aFont = array('font' => $this->fontePadrao, 'size' => 10, 'style' => 'B');
         $this->pdf->textBox($x1, $y + 4, $x3 - 1, 4, $texto, $aFont, 'T', 'L', 0, '', false);
         $x1 += $x3;


### PR DESCRIPTION
https://zucchettibr.atlassian.net/browse/WEB-3642

<p>*<b>Comportamento Atual/Problema</b>*</p>

<p>Ao gerar visualização de um MDF-e Data e hora de emissão estão desalinhados e com o fuso incorreto <a href="https://prnt.sc/5YVPF-E3ySmd" class="external-link" rel="nofollow noreferrer">https://prnt.sc/5YVPF-E3ySmd</a> </p>

<p>*<b>Comportamento esperado/Sugestão de Solução</b>*</p>

<p>Ajuste na visualização do MDF-e para apresentar a Data e Hora de emissão de forma correta</p>

<p>*<b>Passos para reproduzir o comportamento</b>*</p>

<p>Acessar o ZetaWeb<br/>
Acessar o módulo de MDF-e<br/>
Gerar a impressão do DAMDFE numero 14<br/>
Verificar que Data e hora de emissão estão desalinhados e com o fuso incorreto <a href="https://prnt.sc/5YVPF-E3ySmd" class="external-link" rel="nofollow noreferrer">https://prnt.sc/5YVPF-E3ySmd</a></p>

<p>*<b>Informações Adicionais / Processos já efetuados no cliente</b>*</p>

<p>*<b>Anexe os arquivos necessários (XML, prints, etc), se tiver</b>*<br/>
*<b>Link da BDC e serial para acesso</b>*</p>