### PR TITLE
WEB-4387 - 23003 - Numero de autorização do documento não está sendo impresso no DANFCE

### DIFF
--- a/src/NFe/Traits/TraitBlocoXI.php
+++ b/src/NFe/Traits/TraitBlocoXI.php
@@ -28,8 +28,12 @@ trait TraitBlocoXI
 
         foreach ($bandpgto as $p) {
             $p['bandeira'] = $p['bandeira'] ? $this->flagDescription($p['bandeira']) : null;
-            if ($p['bandeira']) {
-                $texto = 'Band. ' . $p['bandeira'] . ' Nº Aut. ' . $p['autorizacao'] . ' R$: ' . $valor;
+            if ($p['autorizacao']) {
+
+                $texto = '';
+                if ($p['bandeira']) $texto .= 'Band. ' . $p['bandeira'];
+                $texto .= ' Nº Aut. ' . str_pad($p['autorizacao'], 6, '0', STR_PAD_LEFT) . ' R$: ' . $valor;
+
                 $this->pdf->textBox($this->margem, $y, $this->wPrint, 3, $texto, $aFont, 'T', 'C', false, '', false);
             }
         }


### PR DESCRIPTION
[//]: # (jira: "{"jiraIssueId":"20731","updatedAt":"2025-04-02T13:28:08.738-0300"}")

> [!NOTE]
> Card: <https://zucchettibr.atlassian.net/browse/WEB-4387> - 23003 - Numero de autorização do documento não está sendo impresso no DANFCE
> Autor: @giovannidalbello

## Descrição
<p>*<b>Comportamento Atual/Problema</b>*</p>

<p>Numero de autorização de venda em cartão ou pix não estão sendo impressas no danfce<br/>
Essa informação consta no XML<br/>
<a href="https://prnt.sc/yg25RIyIVKFk" class="external-link" rel="nofollow noreferrer">https://prnt.sc/yg25RIyIVKFk</a> venda em Cartão (Numero 198) <a href="https://prnt.sc/vt6dc3IH55vI" class="external-link" rel="nofollow noreferrer">https://prnt.sc/vt6dc3IH55vI</a> (impressão)<br/>
<a href="https://prnt.sc/4lxSba9SHp5H" class="external-link" rel="nofollow noreferrer">https://prnt.sc/4lxSba9SHp5H</a> venda no PIX (Numero 199) <a href="https://prnt.sc/riasx3x1bxBT" class="external-link" rel="nofollow noreferrer">https://prnt.sc/riasx3x1bxBT</a> (impressão)</p>


<p>*<b>Comportamento esperado/Sugestão de Solução</b>*</p>

<p>Imprimir o numero de autorização no danfce</p>

<p>*<b>Passos para reproduzir o comportamento</b>*</p>

<p>Vendas na conta anexada no card 198 e 199 <br/>
Emite uma venda em cartão, ou pix,  verifique que no xml consta a informação na tag  &lt;cAut&gt;<br/>
Mas no danfce não é impressa essa informação</p>

<p>*<b>Informações Adicionais / Processos já efetuados no cliente</b>*</p>


<p>*<b>Anexe os arquivos necessários (XML, prints, etc), se tiver</b>*</p>


<p>*<b>Link da BDC e serial para acesso</b>*</p>

## Nota técnica do desenvolvedor
<div class="panel" style="background-color: #ffebe6;border-width: 1px;"><div class="panelContent" style="background-color: #ffebe6;">
<p>Problema:</p>

<p>Não é impresso pois a impressão do dancfe verificar se possui bandeira para imprimir está informação e no nosso caso não temos bandeira pois venda foi realizada via PIX.</p>
</div></div>

<div class="panel" style="background-color: #e3fcef;border-width: 1px;"><div class="panelContent" style="background-color: #e3fcef;">
<p>Solução:</p>

<p>Alterado verificação para imprimir somente quando tiver o cAut e não se tiver cAut e bandeira</p>
</div></div>

<div class="panel" style="background-color: #fffae6;border-width: 1px;"><div class="panelContent" style="background-color: #fffae6;">
<p>Impacto da solução:</p>

<p>Impressão de DANFCFE</p>
</div></div>

<div class="panel" style="background-color: #deebff;border-width: 1px;"><div class="panelContent" style="background-color: #deebff;">
<p>O que testar:</p>

<p>Zweb:</p>

<ul>
	<li>Cenário do card</li>
	<li>NFC-E cartão</li>
	<li>NFC-e prazo<br/>
NFC-e pix</li>
</ul>


<p>Clipp360/Fácil</p>

<ul>
	<li>Cenário do card</li>
	<li>NFC-E cartão</li>
	<li>NFC-e prazo<br/>
NFC-e pix</li>
</ul>
</div></div>

<div class="panel" style="background-color: #eae6ff;border-width: 1px;"><div class="panelContent" style="background-color: #eae6ff;">
<p><b>Atenção!</b></p>

<p>Automação não criou PR segue link <a href="https://github.com/zucchetti-pos/sped-da/pull/39" title="smart-link" class="external-link" rel="nofollow noreferrer">https://github.com/zucchetti-pos/sped-da/pull/39</a> </p>
</div></div>