### PR TITLE
WEB-5386 - 24889 - DANFE Simplificada está sobrepondo descrição de itens e logo.

### DIFF
--- a/src/NFe/Traits/Reduced/Bloco3.php
+++ b/src/NFe/Traits/Reduced/Bloco3.php
@@ -15,7 +15,7 @@ trait Bloco3
         $emitFone = $this->formatPhone($this->getTagValue($this->enderEmit, "fone"));
         $emitEndereco = $this->formatEndereco();
 
-        $h = 20;
+        $h = 15;
         $maxHimg = $h - 2;
         [$xRs, $wRs, $y] = $this->processLogo($y, $h, $maxHimg);
 
@@ -81,7 +81,7 @@ trait Bloco3
         $logoInfo = getimagesize($imagePath);
         $logoWmm = ($logoInfo[0] / 72) * 25.4;
         $logoHmm = ($logoInfo[1] / 72) * 25.4;
-        $nImgW = $this->wPrint / 4;
+        $nImgW = $this->wPrint / 6;
         $nImgH = round($logoHmm * ($nImgW / $logoWmm), 0);
 
         if ($nImgH > $maxHimg) {

--- a/src/NFe/Traits/Reduced/Bloco6.php
+++ b/src/NFe/Traits/Reduced/Bloco6.php
@@ -64,7 +64,7 @@ trait Bloco6
             $x6 = $x5 + ($this->wPrint * $headerPercentage[5]);
 
             $this->pdf->textBox($x, $y2, ($this->wPrint * $headerPercentage[0]), $it->height, $it->codigo, $aFont, 'T', 'L', false, '', true);
-            $this->pdf->textBox($x1, $y2, ($this->wPrint * $headerPercentage[1]), $it->height, $it->desc, $aFont, 'T', 'L', false, '', false);
+            $this->pdf->textBox($x1, $y2, ($this->wPrint * $headerPercentage[1]), $it->height, $it->desc, $aFont, 'T', 'L', false, '', true);
             $this->pdf->textBox($x2, $y2, ($this->wPrint * $headerPercentage[2]), $it->height, $it->qtd, $aFont, 'T', 'R', false, '', true);
             $this->pdf->textBox($x3, $y2, ($this->wPrint * $headerPercentage[3]), $it->height, $it->un, $aFont, 'T', 'C', false, '', true);
             $this->pdf->textBox($x4, $y2, ($this->wPrint * $headerPercentage[4]), $it->height, $it->vunit, $aFont, 'T', 'R', false, '', true);


### PR DESCRIPTION
[//]: # (jira: "{"IssueId":"25507","UpdatedAt":"2025-09-17T16:51:53.957-0300"}")

> [!NOTE]
> Card: <https://zucchettibr.atlassian.net/browse/WEB-5386> - 24889 - DANFE Simplificada está sobrepondo descrição de itens e logo.
> Autor: @gabrielptzlff

## Descrição
<p>*<b>Comportamento Atual/Problema</b>*</p>

<p>DANFE Simplificada está sobrepondo descrição de itens e logo.</p>

<p><a href="https://prnt.sc/P0p2wxr_f11r" class="external-link" rel="nofollow noreferrer">https://prnt.sc/P0p2wxr_f11r</a></p>

<p>DANFE: <a href="https://compufour.s3.amazonaws.com/production/uploads/danfe/35250906212527000166550010000054651645788428.pdf" class="external-link" rel="nofollow noreferrer">https://compufour.s3.amazonaws.com/production/uploads/danfe/35250906212527000166550010000054651645788428.pdf</a></p>

<p>*<b>Comportamento esperado/Sugestão de Solução</b>*</p>

<p>Ajuste na impressão da NF-e Simplificada para os itens e a logo não ficarem sobrepostos</p>

<p>*<b>Passos para reproduzir o comportamento</b>*</p>

<p>Acesse o link: <a href="https://zweb.com.br/#/sign-in" class="external-link" rel="nofollow noreferrer">https://zweb.com.br/#/sign-in</a><br/>
Efetue login na conta em anexo<br/>
Acesse o menu Fiscal &gt; NF-e.<br/>
Selecione a nota número 5465.<br/>
Acesse o menu Ações &gt; Visualizar DANFE.<br/>
Verifique que os itens e a logo ficam sobrepostos. <a href="https://prnt.sc/P0p2wxr_f11r" class="external-link" rel="nofollow noreferrer">https://prnt.sc/P0p2wxr_f11r</a></p>

<p>*<b>Informações Adicionais / Processos já efetuados no cliente</b>*</p>

<p>*<b>Anexe os arquivos necessários (XML, prints, etc), se tiver</b>*</p>

<p>*<b>Link da BDC e serial para acesso</b>*</p>

## Nota técnica do desenvolvedor
<div class="panel" style="background-color: #ffebe6;border-width: 1px;"><div class="panelContent" style="background-color: #ffebe6;">
<p><b>Problema:</b> A DANFE simplificada estava gerando a logo da empresa descentralizada e em alguns casos a descrição do item estava sobrepondo a descrição do item abaixo</p>
</div></div>

<div class="panel" style="background-color: #e3fcef;border-width: 1px;"><div class="panelContent" style="background-color: #e3fcef;">
<p><b>Soluções:</b> </p>

<p><b>Logo da empresa:</b> O tamanho da logo foi reduzido, fazendo com que a logo fique sempre centralizada no bloco de informações da empresa sem afetar o tamanho do bloco</p>

<p><b>Descrição do item:</b> Para montar a quantidade de linhas que a descrição do item vai ocupar no documento, o sistema separa o texto em palavras e valida o tamanho baseado na quantidade de caracteres somado ao tamanho da fonte definido. O limite de caracteres na descrição impressa é de 30 caracteres (sempre irá retornar no máximo duas linhas), acontece que devido ao tamanho da fonte utilizada, mesmo o texto sendo de 30 caracteres o sistema adicionava mais uma quebra de linha no texto devido ao cálculo que excedia o tamanho limite.</p>

<p>Na montagem do bloco dos itens foi adicionada a propriedade <b>force</b> na Descrição, essa propriedade ativa uma condição do método que cria a descrição para que o tamanho da fonte seja reduzido até que o texto se adeque ao limite de largura do campo em duas linhas.</p>
</div></div>

<div class="panel" style="background-color: #deebff;border-width: 1px;"><div class="panelContent" style="background-color: #deebff;">
<p><b>QAs:</b> Para auxiliar no teste, atualizei a documentação do confluence: <a href="https://zucchettibr.atlassian.net/wiki/spaces/PW/pages/228753409/Fluxo+de+PR+s+para+forks+libs" title="smart-link" class="external-link" rel="nofollow noreferrer">https://zucchettibr.atlassian.net/wiki/spaces/PW/pages/228753409/Fluxo+de+PR+s+para+forks+libs</a> </p>

<p>As alterações do card foram feitas no fork <b>sped-da</b>, portanto foi necessário atualizar o composer.json do repo <b>webserver</b> e <b>package-cfe-sat-mfe</b></p>

<p>⚠️  Ao finalizar o teste homolog com sucesso <b>NÃO SUBIR O PR PARA DEPLOY</b></p>

<p>Me chame no privado, pois será necessário subir as alterações do fork <b>sped-da</b> para a master e voltar o apontamento do composer.json para a master em <b>webserver</b>  e <b>package-cfe-sat-mfe</b>, e aí sim o deploy poderá ser realizado.</p>
</div></div>