### PR TITLE
WEB-6212 - 26211 - ZWeb - Caso tenha muitos itens na NFe, as informações complementares ficam entre os itens;

### DIFF
--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -550,9 +550,15 @@ class Danfe extends DaCommon
         //Verificando quantas linhas serão usadas para impressão das duplicatas
         $linhasDup = 0;
         $qtdPag    = 0;
-        if (isset($this->dup) && $this->dup->length > 0) {
+
+        $hasDup = isset($this->dup) && $this->dup->length > 0;
+        $hasDetPag = isset($this->detPag) && $this->detPag->length > 0;
+
+        $considerarDetPag = $this->exibirTextoFatura;
+
+        if ($hasDup) {
             $qtdPag = $this->dup->length;
-        } elseif (isset($this->detPag) && $this->detPag->length > 0) {
+        } elseif ($considerarDetPag && $hasDetPag) {
             $qtdPag = $this->detPag->length;
         }
         if (($qtdPag > 0) && ($qtdPag <= 7)) {

--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -551,14 +551,14 @@ class Danfe extends DaCommon
         $linhasDup = 0;
         $qtdPag    = 0;
 
-        $hasDup = isset($this->dup) && $this->dup->length > 0;
-        $hasDetPag = isset($this->detPag) && $this->detPag->length > 0;
+        $temDup = isset($this->dup) && $this->dup->length > 0;
+        $temDetPag = isset($this->detPag) && $this->detPag->length > 0;
 
         $considerarDetPag = $this->exibirTextoFatura;
 
-        if ($hasDup) {
+        if ($temDup) {
             $qtdPag = $this->dup->length;
-        } elseif ($considerarDetPag && $hasDetPag) {
+        } elseif ($considerarDetPag && $temDetPag) {
             $qtdPag = $this->detPag->length;
         }
         if (($qtdPag > 0) && ($qtdPag <= 7)) {


### PR DESCRIPTION
[//]: # (jira: "{"IssueId":"32909","UpdatedAt":"2026-02-09T15:33:02.318-0300"}")

> [!NOTE]
> Card: <https://zucchettibr.atlassian.net/browse/WEB-6212> - 26211 - ZWeb - Caso tenha muitos itens na NFe, as informações complementares ficam entre os itens;
> Autor: @vdr3w

## Descrição
<p>*<b>Comportamento Atual/Problema</b>*<br/>
Ao emitir uma NFe no ZWeb com muitos itens, o campo de Dados Adicionais fica entre a listagem de itens, sendo que deveria quebrar a página e seguir na sequencia de itens e somente no final da nota apresentar as informações complementares;<br/>
DANFE de exemplo em anexo;</p>

<p>*<b>Comportamento esperado/Sugestão de Solução</b>*<br/>
Manter as informações complementares no final da impressão;</p>

<p>*<b>Passos para reproduzir o comportamento</b>*<br/>
Acessar o zweb;<br/>
Emitir uma NFe com 20 a 30 itens;<br/>
Informar o máximo de caracteres nas informações complementares;<br/>
Transmitir a nota;<br/>
Ao gerar a impressão verá que fica com as informações entre a listagem de item;</p>

<p>*<b>Informações Adicionais / Processos já efetuados no cliente</b>*</p>


<p>*<b>Anexe os arquivos necessários (XML, prints, etc), se tiver</b>*</p>


<p>*<b>Link da BDC e serial para acesso</b>*</p>

## Nota técnica do desenvolvedor
<div class="panel" style="background-color: #ffebe6;border-width: 1px;"><div class="panelContent" style="background-color: #ffebe6;">
<p><b>Problema real (técnico):</b></p>

<p>Basicamente independente da qtd de produtos da NFe, no danfe, as infos complementares ficavam sempre na primeira pagina, cortando os itens pela metade, e ficava ocm o layout estranho com metade dos itens antes da info complementar e metade depois</p>
</div></div>

<div class="panel" style="background-color: #e3fcef;border-width: 1px;"><div class="panelContent" style="background-color: #e3fcef;">
<p><b>Ajuste realizado:</b></p>

<p>Agora foi ajustado para que a info complementar sempre fique na ultima pagina, independente da qtd de itens da nota, nao cortando mais a lista de itens ao meio</p>
</div></div>

<div class="panel" style="background-color: #deebff;border-width: 1px;"><div class="panelContent" style="background-color: #deebff;">
<p><b>Comportamento esperado: (Caso houver mudança de rotina) * Opcional</b></p>

<p>Mesmo cenario do card, porem agora vai dar pra ver q a info complementar sempre fica na ultima pagina</p>

<p>Cenarios testados:</p>

<ul>
	<li>Nota com 40 itens (limite da pagina 1): <a href="https://compufour.s3.amazonaws.com/homolog/uploads/danfe/42260203916076000583550010000515261746454592.pdf" class="external-link" rel="nofollow noreferrer">https://compufour.s3.amazonaws.com/homolog/uploads/danfe/42260203916076000583550010000515261746454592.pdf</a></li>
	<li>Nota com 1 item: <a href="https://compufour.s3.amazonaws.com/homolog/uploads/danfe/42260203916076000583550010000515271117543368.pdf" class="external-link" rel="nofollow noreferrer">https://compufour.s3.amazonaws.com/homolog/uploads/danfe/42260203916076000583550010000515271117543368.pdf</a></li>
</ul>
</div></div>