### PR TITLE
WEB-6260 - 26318 - ZWeb - Rejeição ao emitir NFC-e com troco após importação do Pedido de Venda.

### DIFF
--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -732,19 +732,28 @@ class Danfe extends DaCommon
                 $formaPag[$fPag] = $fPag;
             }
         }
+        
         //caso tenha boleto imprimir fatura
         if ($this->dup->length > 0) {
             $y = $this->fatura($x, $y + 1);
-        } elseif ($this->exibirTextoFatura) {
-            //Se somente tiver a forma de pagamento sem pagamento não imprimir nada
-            if (count($formaPag) == '1' && isset($formaPag[90])) {
-                $y = $y;
-            } else {
-                //caso tenha mais de uma forma de pagamento ou seja diferente de boleto exibe a
-                //forma de pagamento e o valor
-                $y = $this->pagamento($x, $y + 1);
+        }
+
+        $vTroco = 0;
+        $pagList = $this->dom->getElementsByTagName('pag');
+        if ($pagList->length > 0) {
+            $pag = $pagList->item(0);
+
+            $vTrocoList = $pag->getElementsByTagName('vTroco');
+
+            if ($vTrocoList->length > 0) {
+                $vTroco = (float) $vTrocoList->item(0)->nodeValue;
             }
         }
+        
+        if (isset($formaPag['01']) && $vTroco > 0) {
+            $y = $this->pagamento($x, $y + 1);
+        }
+               
         //coloca os dados dos impostos e totais da NFe
         $y = $this->imposto($x, $y + 1);
         //coloca os dados do trasnporte


### PR DESCRIPTION
[//]: # (jira: "{"IssueId":"34563","UpdatedAt":"2026-02-12T08:49:58.803-0300"}")

> [!NOTE]
> Card: <https://zucchettibr.atlassian.net/browse/WEB-6260> - 26318 - ZWeb - Rejeição ao emitir NFC-e com troco após importação do Pedido de Venda.
> Autor: @ASangelina

## Descrição
<p>*<b>Comportamento Atual/Problema</b>*<br/>
Ao importar um Pedido de Venda para NFC-e e informar um valor de pagamento maior que o total da nota para geração de troco, ao tentar transmitir a NFC-e o sistema retorna a rejeição: “Ausência de troco quando o valor dos pagamentos informados for maior que o total da nota”, mesmo havendo valor de troco informado.</p>

<p>Além disso, após a rejeição, a NFC-e não é salva na listagem com o status “Rejeitada”, o que impede a verificação do XML para análise do problema.</p>

<p>Quando a NFC-e é emitida sem importar um Pedido de Venda e é informado um valor maior para geração de troco, a nota é autorizada normalmente, sem apresentar a rejeição.</p>

<p>*<b>Comportamento esperado/Sugestão de Solução</b>*<br/>
Ajustar o fluxo de importação do Pedido de Venda para NFC-e para que o sistema identifique corretamente o valor de troco informado, permitindo a emissão da nota normalmente.</p>

<p>*<b>Passos para reproduzir o comportamento</b>*<br/>
1- Criar um Pedido de Venda.<br/>
2- Importar esse Pedido de Venda para NFC-e.<br/>
3- Informar um valor de pagamento maior que o total da nota, gerando troco.<br/>
4- Tentar transmitir a NFC-e.<br/>
5- Verifique que o sistema retorna a rejeição de ausência de troco mesmo com o troco informado.<br/>
6- Verificar que a NFC-e não aparece salva na listagem como rejeitada.</p>

<p>*<b>Informações Adicionais / Processos já efetuados no cliente</b>*</p>
<ul class="alternate" type="square">
	<li>Situação reportada inicialmente por um cliente, feito testes internamente e a situação também ocorre.</li>
</ul>


<p>*<b>Anexe os arquivos necessários (XML, prints, etc), se tiver</b>*</p>
<ul class="alternate" type="square">
	<li>Print da rejeição.</li>
</ul>


<p>*<b>Link da BDC e serial para acesso</b>*<br/>
G37LBG061771 - Anderson</p>

## Nota técnica do desenvolvedor
<div class="panel" style="background-color: #ffebe6;border-width: 1px;"><div class="panelContent" style="background-color: #ffebe6;">
<p><b>Problema real (técnico):</b></p>
</div></div>

<ul>
	<li>O problema acontece quando o cliente é CNPJ, e tem a configuração Bloquear NFC-e para CNPJ, os pagamentos não serão feitos com troco</li>
	<li>Ajustar para ter o troco</li>
	<li>Foi comparado o comportamento com a outra solução WEB, aprovado pelo PO para ter o troco, que é o que está causando a rejeição, e ter na Danfe A4 o pagamento quando é dinheiro e troco</li>
</ul>


<div class="panel" style="background-color: #e3fcef;border-width: 1px;"><div class="panelContent" style="background-color: #e3fcef;">
<p><b>Ajuste realizado:</b></p>
</div></div>

<ul>
	<li>Ajustado para permitir troco na NF-e a partir da NFC-e por bloqueio de CNPJ na NFC-e</li>
	<li>Ajustado DANFE A4 para apresentar pagamento</li>
</ul>


<div class="panel" style="background-color: #deebff;border-width: 1px;"><div class="panelContent" style="background-color: #deebff;">
<p><b>Comportamento esperado: (Caso houver mudança de rotina) * Opcional</b></p>
</div></div>

<ul>
	<li>XML apresentará o troco</li>
	<li>Danfe A4 apresentará Pagamento</li>
</ul>


<div class="panel" style="background-color: #fffae6;border-width: 1px;"><div class="panelContent" style="background-color: #fffae6;">
<p><b>Sugestão de testes:</b></p>
</div></div>

<ul>
	<li>Para conseguir testar, vai precisar do código da tarefa: <a href="https://zucchettibr.atlassian.net/browse/WEB-6268" title="smart-link" class="external-link" rel="nofollow noreferrer">https://zucchettibr.atlassian.net/browse/WEB-6268</a></li>
	<li>Testar NFC-e com bloqueio de CNPJ, importando ou não, com troco</li>
	<li>Testar Danfe A4 para apresentá o pagamento quando for dinheiro e tiver troco</li>
</ul>
