### PR TITLE
WEB-6212 - 26211 - ZWeb - Caso tenha muitos itens na NFe, as informações complementares ficam entre os itens;

### DIFF
--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -638,13 +638,15 @@ class Danfe extends DaCommon
         //$hDispo1 += 14;
         $hDispo2 = $this->hPrint - ($hcabecalho + $hfooter + $hCabecItens);
 
-        // InfoComplementar fica sempre na ultima pagina ( se tiver 1 pagina, fica nela, se tiver mais de uma 1 pagina, vai pra ultima)
-        $hDispoLast = $hDispo2 - $this->hdadosadic;
+        // Y inicial do bloco de dados adicionais (parte superior da caixa).
+        // Se os itens avançarem além deste ponto, os dados adicionais devem ir para a próxima página.
+        $yInicioDadosAdicionais = $this->maxH - (7 + $this->hdadosadic);
+        $hDadosAdicReal = $this->hdadosadic + 3;
+        $hDispoLast = $hDispo2 - $hDadosAdicReal;
         if ($hDispoLast < $hCabecItens) {
             $hDispoLast = $hCabecItens;
         }
-
-        $hDispo1ComDados = $hDispo1 - $this->hdadosadic;
+        $hDispo1ComDados = $hDispo1 - $hDadosAdicReal;
         if ($hDispo1ComDados < $hCabecItens) {
             $hDispo1ComDados = $hCabecItens;
         }
@@ -692,7 +694,7 @@ class Danfe extends DaCommon
 
         // Se itens + quadro final não couberem na última página, força criar nova página
         $hUltimaDisponivel = ($totPag === 1) ? $hDispo1 : $hDispo2;
-        if (($hUsado + $this->hdadosadic) > $hUltimaDisponivel) {
+        if (($hUsado + $hDadosAdicReal) > $hUltimaDisponivel) {
             $totPag++;
         }
 
@@ -752,6 +754,7 @@ class Danfe extends DaCommon
         //itens da DANFE
         $nInicial = 0;
 
+        $this->qtdeItensProc = 0;
         $hPrimeiraPagina = ($totPag === 1) ? $hDispo1ComDados : $hDispo1;
         $y = $this->itens($x, $y + 1, $nInicial, $hPrimeiraPagina, $pag, $totPag, $hCabecItens);
         // Garante que a próxima página continue do último item processado
@@ -762,6 +765,14 @@ class Danfe extends DaCommon
             $y = $this->issqn($x, $y + 4);
         } else {
             $y += 4;
+        }
+        // prioridade para itens: se ainda houver itens, cria nova página antes dos dados adicionais
+        if ($pag == $totPag && $this->qtdeItensProc < $qtdeItens) {
+            $totPag++;
+        }
+        // se os itens ocuparam a área do quadro final, joga os dados adicionais para a próxima página
+        if ($pag == $totPag && $this->qtdeItensProc == $qtdeItens && $this->yDados > $yInicioDadosAdicionais) {
+            $totPag++;
         }
         //coloca os dados adicionais apenas na última página
         if ($pag == $totPag) {
@@ -794,21 +805,28 @@ class Danfe extends DaCommon
             $y = $this->itens($x, $y + 1, $nInicial, $hDispoPagina, $n, $totPag, $hCabecItens);
             // Atualiza ponto de continuidade para a próxima página
             $nInicial = $this->qtdeItensProc;
+            //se estiver na última página e ainda restar itens para inserir, adiciona mais uma página
+            if ($n == $totPag && $this->qtdeItensProc < $qtdeItens) {
+                $totPag++;
+            }
+            // se os itens desta página avançaram na área dos dados adicionais, cria uma página extra para o quadro final
+            if (
+                $n == $totPag
+                && $this->qtdeItensProc == $qtdeItens
+                && $this->yDados > $yInicioDadosAdicionais
+            ) {
+                $totPag++;
+            }
             //coloca os dados adicionais na última página
             if ($n == $totPag) {
                 $y = $this->dadosAdicionais($x, $y, $this->hdadosadic);
             }
-
 
             //coloca o rodapé da página
             if ($this->orientacao == 'P') {
                 $this->rodape($this->margesq);
             } else {
                 $this->rodape($this->margesq);
-            }
-            //se estiver na última página e ainda restar itens para inserir, adiciona mais uma página
-            if ($n == $totPag && $this->qtdeItensProc < $qtdeItens) {
-                $totPag++;
             }
         }
     }
@@ -3424,6 +3442,7 @@ class Danfe extends DaCommon
             }
         }
 
+        $this->yDados = $y;
         return $oldY + $hmax;
     }
 


### PR DESCRIPTION
[//]: # (jira: "{"IssueId":"32909","UpdatedAt":"2026-02-12T14:59:33.019-0300"}")

> [!NOTE]
> Card: <https://zucchettibr.atlassian.net/browse/WEB-6212> - 26211 - ZWeb - Caso tenha muitos itens na NFe, as informações complementares ficam entre os itens;
> Autor: @vdr3w

## Descrição
<p>*<b>Comportamento Atual/Problema</b>*<br/>
Ao emitir uma NFe no ZWeb com muitos itens, o campo de Dados Adicionais fica entre a listagem de itens, sendo que deveria quebrar a página e seguir na sequencia de itens e somente no final da nota apresentar as informações complementares;<br/>
DANFE de exemplo em anexo;</p>

<p>*<b>Comportamento esperado/Sugestão de Solução</b>*<br/>
Manter as informações complementares no final da impressão;</p>

<p>*<b>Passos para reproduzir o comportamento</b>*<br/>
Acessar o zweb;<br/>
Emitir uma NFe com 20 a 30 itens;<br/>
Informar o máximo de caracteres nas informações complementares;<br/>
Transmitir a nota;<br/>
Ao gerar a impressão verá que fica com as informações entre a listagem de item;</p>

<p>*<b>Informações Adicionais / Processos já efetuados no cliente</b>*</p>


<p>*<b>Anexe os arquivos necessários (XML, prints, etc), se tiver</b>*</p>


<p>*<b>Link da BDC e serial para acesso</b>*</p>

## Nota técnica do desenvolvedor
<div class="panel" style="background-color: #ffebe6;border-width: 1px;"><div class="panelContent" style="background-color: #ffebe6;">
<p><b>Problema real (técnico):</b></p>

<p>Basicamente independente da qtd de produtos da NFe, no danfe, as infos complementares ficavam sempre na primeira pagina, cortando os itens pela metade, e ficava ocm o layout estranho com metade dos itens antes da info complementar e metade depois</p>
</div></div>

<div class="panel" style="background-color: #e3fcef;border-width: 1px;"><div class="panelContent" style="background-color: #e3fcef;">
<p><b>Ajuste realizado:</b></p>

<p>Agora foi ajustado para que a info complementar sempre fique na ultima pagina, independente da qtd de itens da nota, nao cortando mais a lista de itens ao meio</p>
</div></div>

<div class="panel" style="background-color: #deebff;border-width: 1px;"><div class="panelContent" style="background-color: #deebff;">
<p><b>Comportamento esperado: (Caso houver mudança de rotina) * Opcional</b></p>

<p>Mesmo cenario do card, porem agora vai dar pra ver q a info complementar sempre fica na ultima pagina</p>

<p>Cenarios testados:</p>

<ul>
	<li>Nota com 40 itens (limite da pagina 1): <a href="https://compufour.s3.amazonaws.com/homolog/uploads/danfe/42260203916076000583550010000515261746454592.pdf" class="external-link" rel="nofollow noreferrer">https://compufour.s3.amazonaws.com/homolog/uploads/danfe/42260203916076000583550010000515261746454592.pdf</a></li>
	<li>Nota com 1 item: <a href="https://compufour.s3.amazonaws.com/homolog/uploads/danfe/42260203916076000583550010000515271117543368.pdf" class="external-link" rel="nofollow noreferrer">https://compufour.s3.amazonaws.com/homolog/uploads/danfe/42260203916076000583550010000515271117543368.pdf</a></li>
</ul>
</div></div>