### PR TITLE
WEB-7271 - fix: remove linha duplicada de tributos aproximados (Lei 12.741) na DANFCE

### DIFF
--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -449,11 +449,9 @@ class Danfe extends DaCommon
         //verificar se a informação sobre o valor aproximado dos tributos
         //já se encontra no campo de informações adicionais
         if ($this->exibirValorTributos) {
-            $flagVTT = strpos(strtolower(trim($this->textoAdic)), 'valor');
-            $flagVTT = $flagVTT || strpos(strtolower(trim($this->textoAdic)), 'vl');
-            $flagVTT = $flagVTT && strpos(strtolower(trim($this->textoAdic)), 'aprox');
-            $flagVTT = $flagVTT && (strpos(strtolower(trim($this->textoAdic)), 'trib') ||
-                strpos(strtolower(trim($this->textoAdic)), 'imp'));
+            $textoAdicLower = strtolower(trim($this->textoAdic));
+            $flagVTT = strpos($textoAdicLower, 'aprox') !== false
+                && (strpos($textoAdicLower, 'trib') !== false || strpos($textoAdicLower, 'imp') !== false);
             $vTotTrib = $this->getTagValue($this->ICMSTot, 'vTotTrib');
             if ($vTotTrib != '' && !$flagVTT) {
                 $this->textoAdic .= "\n Valor Aproximado dos Tributos : R$ "

--- a/src/NFe/Traits/Reduced/Bloco8.php
+++ b/src/NFe/Traits/Reduced/Bloco8.php
@@ -17,6 +17,14 @@ trait Bloco8
 
     protected function fillTributosInfo($y)
     {
+        $infCplLower = strtolower(trim($this->infCpl));
+        $flagVTT = strpos($infCplLower, 'aprox') !== false
+            && (strpos($infCplLower, 'trib') !== false || strpos($infCplLower, 'imp') !== false);
+
+        if ($flagVTT) {
+            return $y;
+        }
+
         $valor = $this->getTagValue($this->ICMSTot, 'vTotTrib');
         $trib = !empty($valor) ? number_format((float) $valor, 2, ',', '.') : '-----';
         $texto = "Informação dos Tributos Totais Incidentes (Lei Federal 12.742/2012): R$ {$trib}";

--- a/src/NFe/Traits/Reduced/Bloco8.php
+++ b/src/NFe/Traits/Reduced/Bloco8.php
@@ -9,18 +9,24 @@ trait Bloco8
 {
     protected function bloco8($y)
     {
-        $y = $this->fillTributosInfo($y);
-        $y = $this->fillComplementaryInfo($y);
+        $flagVTT = $this->hasApproxTaxInfo();
+
+        $y = $this->fillTributosInfo($y, $flagVTT);
+        $y = $this->fillComplementaryInfo($y, $flagVTT);
 
         return $y + 4;
     }
 
-    protected function fillTributosInfo($y)
+    private function hasApproxTaxInfo(): bool
     {
         $infCplLower = strtolower(trim($this->infCpl));
-        $flagVTT = strpos($infCplLower, 'aprox') !== false
-            && (strpos($infCplLower, 'trib') !== false || strpos($infCplLower, 'imp') !== false);
 
+        return strpos($infCplLower, 'aprox') !== false
+            && (strpos($infCplLower, 'trib') !== false || strpos($infCplLower, 'imp') !== false);
+    }
+
+    protected function fillTributosInfo($y, $flagVTT)
+    {
         if ($flagVTT) {
             return $y;
         }
@@ -48,16 +54,17 @@ trait Bloco8
         return $y;
     }
 
-    protected function fillComplementaryInfo($y)
+    protected function fillComplementaryInfo($y, $flagVTT = false)
     {
         $aFont = ['font' => $this->fontePadrao, 'size' => 8, 'style' => ''];
         if ($this->paperwidth < 70) {
             $aFont['size'] = 5;
         }
 
+        $offset = $flagVTT ? 0 : 4;
         $y += $this->pdf->textBox(
             $this->margem,
-            $y + 4,
+            $y + $offset,
             $this->wPrint,
             8,
             str_replace(";", "\n", $this->infCpl),

--- a/src/NFe/Traits/Reduced/Helper.php
+++ b/src/NFe/Traits/Reduced/Helper.php
@@ -141,15 +141,18 @@ trait Helper
             $aFont['size'] = 5;
         }
 
-        $textoTributos = "Informação dos Tributos Totais Incidentes (Lei Federal 12.742/2012)";
         $linhasCpl = str_replace(';', "\n", $this->infCpl);
+        $infCplLower = strtolower(trim($this->infCpl));
+        $flagVTT = strpos($infCplLower, 'aprox') !== false
+            && (strpos($infCplLower, 'trib') !== false || strpos($infCplLower, 'imp') !== false);
 
         $hfont = (imagefontheight($fontSize) / 72) * 14;
 
-        $numLinhas =
-            (int) $pdf->getNumLines($textoTributos, $wprint, $aFont) +
-            (int) $pdf->getNumLines($linhasCpl, $wprint, $aFont) +
-            2;
+        $numLinhas = (int) $pdf->getNumLines($linhasCpl, $wprint, $aFont) + 2;
+        if (!$flagVTT) {
+            $textoTributos = "Informação dos Tributos Totais Incidentes (Lei Federal 12.742/2012)";
+            $numLinhas += (int) $pdf->getNumLines($textoTributos, $wprint, $aFont);
+        }
 
         return (int) ($numLinhas * $hfont) + $this->margem;
     }

--- a/src/NFe/Traits/Reduced/Helper.php
+++ b/src/NFe/Traits/Reduced/Helper.php
@@ -142,9 +142,7 @@ trait Helper
         }
 
         $linhasCpl = str_replace(';', "\n", $this->infCpl);
-        $infCplLower = strtolower(trim($this->infCpl));
-        $flagVTT = strpos($infCplLower, 'aprox') !== false
-            && (strpos($infCplLower, 'trib') !== false || strpos($infCplLower, 'imp') !== false);
+        $flagVTT = $this->hasApproxTaxInfo();
 
         $hfont = (imagefontheight($fontSize) / 72) * 14;
 

--- a/src/NFe/Traits/TraitBlocoIX.php
+++ b/src/NFe/Traits/TraitBlocoIX.php
@@ -11,27 +11,10 @@ trait TraitBlocoIX
 {
     protected function blocoIX($y)
     {
-        $valor = $this->getTagValue($this->ICMSTot, 'vTotTrib');
-        $trib = !empty($valor) ? number_format((float) $valor, 2, ',', '.') : '-----';
-        $texto = "Tributos totais Incidentes (Lei Federal 12.741/2012): R$ {$trib}";
         $aFont = ['font' => $this->fontePadrao, 'size' => 7, 'style' => ''];
-        $this->pdf->textBox(
-            $this->margem,
-            $y,
-            $this->wPrint,
-            $this->bloco9H,
-            $texto,
-            $aFont,
-            'T',
-            'L',
-            false,
-            '',
-            true
-        );
         if ($this->paperwidth < 70) {
             $aFont = ['font'=> $this->fontePadrao, 'size' => 5, 'style' => ''];
         }
-        $y += 3;
         $this->pdf->textBox(
             $this->margem,
             $y,


### PR DESCRIPTION
## Problema
No DANFCE (NFC-e), o rodapé exibia duas vezes a mesma informação de tributos aproximados do IBPT:
- "Tributos totais Incidentes (Lei Federal 12.741/2012): R$ X"
- "Trib aprox Fed: R$ X, Est: R$ X, Mun: R$ X, Fonte: IBPT/..."

 A primeira linha é gerada automaticamente por `TraitBlocoIX::blocoIX()`, lendo `ICMSTot/vTotTrib` do XML da nota. A segunda vem do campo `infCpl` (informação complementar), montado pela aplicação (`Fiscal\Service\NFE\Builder\InfCplBuilder::calcIBPT()`) e impresso logo abaixo pelo mesmo método. Ambas mostram, em formatos diferentes, o mesmo cálculo de tributo aproximado — resultando em duplicidade visual no documento impresso.

 ## Ajuste
 Removida a construção e impressão da linha "Tributos totais Incidentes (Lei Federal 12.741/2012)" em `TraitBlocoIX::blocoIX()`. O bloco passa a imprimir apenas o conteúdo de `infCpl` (que já contém a informação do IBPT no formato "Trib aprox").

 Esse trait é usado exclusivamente pela classe `Danfce` (NFC-e); a DANFE de NF-e modelo 55 não usa esse trait e não é afetada.

 ## Escopo
 - Arquivo alterado: `src/NFe/Traits/TraitBlocoIX.php`
 - Afeta apenas a geração de DANFCE (NFC-e) via `NFePHP\DA\NFe\Danfce`.
 - Não afeta o XML da nota nem a transmissão à SEFAZ — é uma alteração puramente de layout de impressão.