### PR TITLE
WEB-7414: remove soma indevida de vFCP/vFCPST em VALOR DO ICMS/VALOR DO ICMS SUBST. na DANFE

### DIFF
--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -2317,23 +2317,11 @@ class Danfe extends DaCommon
     protected function impostoHelper($x, $y, $w, $h, $titulo, $campoImposto)
     {
         $value = 0;
-        $value2 = 0;
         $the_field = $this->ICMSTot->getElementsByTagName($campoImposto)->item(0);
         if (isset($the_field)) {
             $value = $the_field->nodeValue;
-            if ($campoImposto == 'vICMS') { // soma junto ao ICMS o FCP
-                $the_field_aux = $this->ICMSTot->getElementsByTagName('vFCP')->item(0);
-                if (isset($the_field_aux)) {
-                    $value2 = $the_field_aux->nodeValue;
-                }
-            } elseif ($campoImposto == 'vST') { // soma junto ao ICMS ST o FCP ST
-                $the_field_aux = $this->ICMSTot->getElementsByTagName('vFCPST')->item(0);
-                if (isset($the_field_aux)) {
-                    $value2 = $the_field_aux->nodeValue;
-                }
-            }
         }
-        $valorImposto = number_format($value + $value2, 2, ",", ".");
+        $valorImposto = number_format($value, 2, ",", ".");
 
         $fontTitulo = ['font' => $this->fontePadrao, 'size' => 6, 'style' => ''];
         $fontValor  = ['font' => $this->fontePadrao, 'size' => 10, 'style' => 'B'];

--- a/tests/NFe/ImpostoHelperFcpTest.php
+++ b/tests/NFe/ImpostoHelperFcpTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace NFePHP\DA\Tests\NFe;
+
+use DOMDocument;
+use NFePHP\DA\NFe\Danfe;
+use NFePHP\DA\Legacy\Pdf;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+class ImpostoHelperFcpTest extends TestCase
+{
+    private function buildICMSTot(array $valores): \DOMElement
+    {
+        $dom = new DOMDocument();
+        $icmsTot = $dom->createElement('ICMSTot');
+        foreach ($valores as $tag => $valor) {
+            $icmsTot->appendChild($dom->createElement($tag, (string) $valor));
+        }
+        $dom->appendChild($icmsTot);
+
+        return $icmsTot;
+    }
+
+    private function buildDanfeWithIcmsTot(\DOMElement $icmsTot): Danfe
+    {
+        $reflection = new ReflectionClass(Danfe::class);
+        /** @var Danfe $danfe */
+        $danfe = $reflection->newInstanceWithoutConstructor();
+
+        $icmsTotProp = $reflection->getProperty('ICMSTot');
+        $icmsTotProp->setAccessible(true);
+        $icmsTotProp->setValue($danfe, $icmsTot);
+
+        $fontProp = $reflection->getParentClass()->getProperty('fontePadrao');
+        $fontProp->setAccessible(true);
+        $fontProp->setValue($danfe, 'Times');
+
+        $pdfProp = $reflection->getParentClass()->getProperty('pdf');
+        $pdfProp->setAccessible(true);
+        $pdfProp->setValue($danfe, new class extends Pdf {
+            public array $valoresImpressos = [];
+
+            public function textBox(
+                $x,
+                $y,
+                $w,
+                $h,
+                $text = '',
+                $aFont = ['font' => 'Times', 'size' => 8, 'style' => ''],
+                $vAlign = 'T',
+                $hAlign = 'L',
+                $border = true,
+                $link = '',
+                $force = true,
+                $hmax = 0,
+                $vOffSet = 0,
+                $fill = false
+            ) {
+                if ($hAlign === 'R') {
+                    $this->valoresImpressos[] = $text;
+                }
+
+                return $y;
+            }
+        });
+
+        return $danfe;
+    }
+
+    private function callImpostoHelper(Danfe $danfe, string $campoImposto): string
+    {
+        $reflection = new ReflectionClass(Danfe::class);
+        $method = $reflection->getMethod('impostoHelper');
+        $method->setAccessible(true);
+        $method->invoke($danfe, 0, 0, 10, 10, 'TITULO', $campoImposto);
+
+        $pdfProp = $reflection->getParentClass()->getProperty('pdf');
+        $pdfProp->setAccessible(true);
+        $pdf = $pdfProp->getValue($danfe);
+
+        return end($pdf->valoresImpressos);
+    }
+
+    public function test_valorDoIcms_naoDeveSomarVfcp(): void
+    {
+        $icmsTot = $this->buildICMSTot([
+            'vICMS' => '112.15',
+            'vFCP' => '18.69',
+        ]);
+        $danfe = $this->buildDanfeWithIcmsTot($icmsTot);
+
+        $valorImpresso = $this->callImpostoHelper($danfe, 'vICMS');
+
+        $this->assertSame('112,15', $valorImpresso);
+    }
+
+    public function test_valorDoIcmsSubst_naoDeveSomarVfcpst(): void
+    {
+        $icmsTot = $this->buildICMSTot([
+            'vST' => '135.68',
+            'vFCPST' => '22.61',
+        ]);
+        $danfe = $this->buildDanfeWithIcmsTot($icmsTot);
+
+        $valorImpresso = $this->callImpostoHelper($danfe, 'vST');
+
+        $this->assertSame('135,68', $valorImpresso);
+    }
+
+    public function test_valorDoIcms_semFcpNaNota_continuaFuncionando(): void
+    {
+        $icmsTot = $this->buildICMSTot([
+            'vICMS' => '50.00',
+        ]);
+        $danfe = $this->buildDanfeWithIcmsTot($icmsTot);
+
+        $valorImpresso = $this->callImpostoHelper($danfe, 'vICMS');
+
+        $this->assertSame('50,00', $valorImpresso);
+    }
+}


### PR DESCRIPTION
## Problema
A DANFE soma indevidamente `vFCP` ao "VALOR DO ICMS" e `vFCPST` ao "VALOR DO ICMS SUBST.", gerando divergência com o XML da NF-e (incidente 28894).

## Causa
`impostoHelper()` em `src/NFe/Danfe.php` somava `vFCP`/`vFCPST` aos campos `vICMS`/`vST` só para exibição, propositalmente (herdado de um commit upstream sem justificativa/PR — nfephp-org/sped-da@d903650).

## Correção
Remove a soma; "VALOR DO ICMS" e "VALOR DO ICMS SUBST." agora exibem exatamente `vICMS`/`vST` do XML, sem somar FCP.

## Base legal
MOC 7.0 (CONFAZ), grupo `ICMSTot`: `vICMS` (W04) e `vFCP` (W04h) são totalizadores independentes desde a NT 2016.002 (`vFCP` = "total da soma dos campos id: N17c"), idem para `vST`(W06)/`vFCPST`(W06a). Não há previsão normativa pra somar.